### PR TITLE
Fix typo: Use org.gnome.Dictionary 3.20

### DIFF
--- a/docs/building-simple-apps.rst
+++ b/docs/building-simple-apps.rst
@@ -7,13 +7,13 @@ Installing an SDK
 -----------------
 
 As described above, an SDK is a special type of runtime that is used to build applcations. Typically, an SDK is paired with a runtime that will be used by the app at runtime. For example the GNOME 3.22 SDK is used to build applications that use the GNOME 3.22 runtime. The rest of this guide uses this SDK and runtime for its examples. To do this, download the repository GPG key and then add the repository that contains the runtime and SDK::
-  
+
   $ flatpak remote-add --from gnome https://sdk.gnome.org/gnome.flatpakrepo
 
 You can now download and install the runtime and SDK. (If you have already completed the tutorial on the Flatpak homepage, you will already have the runtime installed.) ::
 
   $ flatpak install gnome org.gnome.Platform//3.22 org.gnome.Sdk//3.22
- 
+
 This might be a good time to try installing an application and having a look 'under the hood'. To do this, you need to add a repository that contains applications. In this case we are going to use the gnome-apps repository and install gedit::
 
   $ flatpak remote-add --from gnome-apps https://sdk.gnome.org/gnome-apps.flatpakrepo
@@ -50,14 +50,14 @@ Building
 ``flatpak build`` is used to build an application using an SDK. This command is used to provide access to a sandbox. For example, the following will create a file inside the appdir sandbox (in the files directory)::
 
   $ flatpak build dictionary touch /app/some_file
-  
+
 (It is best to remove this file before continuing.)
 
 The build command allows existing applications that have been made using the traditional configure, make, make install routine to be built inside a flatpak. You can try this using GNOME Dictionary. First, download the source files, extract them and switch to the resulting directory::
 
-  $ wget https://download.gnome.org/sources/gnome-dictionary/3.22/gnome-dictionary-3.22.0.tar.xz
-  $ tar xvf gnome-dictionary-3.22.0.tar.xz
-  $ cd gnome-dictionary-3.22.0/
+  $ wget https://download.gnome.org/sources/gnome-dictionary/3.20/gnome-dictionary-3.20.0.tar.xz
+  $ tar xvf gnome-dictionary-3.20.0.tar.xz
+  $ cd gnome-dictionary-3.20.0/
 
 Then you can use the build command to build and install the source inside the dictionary directory that was previously made::
 
@@ -74,7 +74,7 @@ Completing the build
 Once an application has been built, the ``build-finish`` command needs to be used to specify access to different parts of the host, such as networking and graphics sockets. This command is also used to specify the command that is used to run the app (done by modifying the metadata file), and to create the application's exports directory. For example::
 
   $ flatpak build-finish dictionary --socket=x11 --share=network --command=gnome-dictionary
-  
+
 At this point you have successfully built a flatpak and prepared it to be run. To test the app, you need to export the Dictionary to a repository, add that repository and then install and run the app::
 
   $ flatpak build-export repo dictionary
@@ -83,4 +83,3 @@ At this point you have successfully built a flatpak and prepared it to be run. T
   $ flatpak run org.gnome.Dictionary
 
 This exports the app, creates a repository called tutorial-repo, installs the Dictionary application in the per-user installation area and runs it.
-

--- a/docs/flatpak-builder.rst
+++ b/docs/flatpak-builder.rst
@@ -18,9 +18,9 @@ The GNOME Dictionary manifest is short, because the only module is the applicati
     "runtime-version": "3.22",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-dictionary",
-    "finish-args": [ 
-       "--socket=x11", 
-       "--share=network"  
+    "finish-args": [
+       "--socket=x11",
+       "--share=network"
     ],
     "modules": [
       {
@@ -28,7 +28,7 @@ The GNOME Dictionary manifest is short, because the only module is the applicati
         "sources": [
           {
             "type": "archive",
-            "url": "https://download.gnome.org/sources/gnome-dictionary/3.22/gnome-dictionary-3.22.0.tar.xz",
+            "url": "https://download.gnome.org/sources/gnome-dictionary/3.20/gnome-dictionary-3.20.0.tar.xz",
             "sha256": "efb36377d46eff9291d3b8fec37baab2355f9dc8bc7edb791b6a625574716121"
           }
         ]
@@ -67,7 +67,7 @@ Example
 You can try flatpak-builder for yourself, using the repository that was created in the previous section. To do this, place the manifest json from above into a file called ``org.gnome.Dictionary.json`` and run the following command::
 
   $ flatpak-builder --repo=repo dictionary2 org.gnome.Dictionary.json
-  
+
 This will:
 
 * Create a new directory (called dictionary2)
@@ -86,11 +86,11 @@ To check that the application has been successfully updated, you can compare the
 
   $ flatpak info org.gnome.Dictionary
   $ flatpak info org.gnome.Dictionary.Locale
-  
+
 And finally, you can run the new version of the Dictionary app::
 
   $ flatpak run org.gnome.Dictionary
-  
+
 Example manifests
 -----------------
 


### PR DESCRIPTION
The readme is using org.gnome.Dictionary 3.22 xz and it should be 3.20. Note that the sha256sum in `flatpak-builder.rst` matches dictionary 3.20. Also removed trailing whitespace (good catch Atom).

I found this while reading through http://flatpak.org/developer.html, I think this is the correct repo to update that site.