### PR TITLE
flatpak-builder: Make the process standalone

### DIFF
--- a/docs/flatpak-builder.rst
+++ b/docs/flatpak-builder.rst
@@ -68,17 +68,17 @@ When flatpak-builder exports the build into a repository, it automatically inclu
 Example
 -------
 
-You can try flatpak-builder for yourself, using the repository that was created in the `previous section <building-simple-apps.html>`_. To do this, place the manifest JSON from above into a file called ``org.gnome.Dictionary.json`` and run the following command::
+You can try flatpak-builder for yourself. To do this, place the manifest JSON from above into a file called ``org.gnome.Dictionary.json`` and run the following command::
 
   $ flatpak-builder --repo=repo dictionary2 org.gnome.Dictionary.json
 
 This will:
 
-* Create a new directory (called dictionary2)
+* Create a new directory called dictionary2 (with the same result as setting it up manually with "flatpak build-init").
 * Download and verify the Dictionary source code
 * Build and install the source code, using the SDK rather than the host system
 * Finish the build, by setting permissions (in this case giving access to X and the network)
-* Export the resulting build to the tutorial repository, which contains the Dictionary app that was previously installed
+* Create new repository called repo if it doesn't exist and export the resulting build to it
 
 flatpak-builder will also do some other useful things, like creating a separately installable debug runtime (called `org.gnome.Dictionary.Debug` in this case) and a separately installable translation runtime (called ``org.gnome.Dictionary.Locale``).
 


### PR DESCRIPTION
Usually we already have some .json, and if not, usually is more comfortable to have a file where you can edit etc. than fiddling around with comman lines.

In the tutorial, we refer to a previous section to install in a repo. The section uses build-init and in no place it says what is necessary from that section to actually use flatpak-builder, so the dev ends up doing the whole thing instead of just using flatpak-builder with the json file.

For that, make it simpler and more straightforward making the flatpak-builder tutorial standalone, ready to be used with no previous set up.