### PR TITLE
flatpak-builder.rst: Remove build API rule

### DIFF
--- a/docs/flatpak-builder.rst
+++ b/docs/flatpak-builder.rst
@@ -3,6 +3,8 @@ Flatpak Builder
 
 Most applications require additional dependencies that aren't provided by their runtimes. Flatpak allows these dependencies to be bundled as part of the application itself. In order to do this, each dependency must be built inside the application build directory. The ``flatpak-builder`` tool automates this multi-step build process, making it possible to build all application modules with a single command.
 
+flatpak-builder supports a variety of build systems, including `autotools <https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html>`_, `cmake <https://cmake.org/>`_, `cmake-ninja <https://cmake.org/cmake/help/v3.0/generator/Ninja.html>`_, `meson <http://mesonbuild.com/>`_, a simple one called "simple" which allows to provide a serie of commands to run, and the so called `Build API <https://github.com/cgwalters/build-api/>`_.
+
 All json entities are explained in the man page of ``flatpak-builder``.
 
 Manifests

--- a/docs/flatpak-builder.rst
+++ b/docs/flatpak-builder.rst
@@ -3,8 +3,6 @@ Flatpak Builder
 
 Most applications require additional dependencies that aren't provided by their runtimes. Flatpak allows these dependencies to be bundled as part of the application itself. In order to do this, each dependency must be built inside the application build directory. The ``flatpak-builder`` tool automates this multi-step build process, making it possible to build all application modules with a single command.
 
-flatpak-builder expects modules to be built in the standard manner by following what is called the `Build API <https://github.com/cgwalters/build-api/>`_. This requires modifying modules to follow the build API, if they don't already.
-
 All json entities are explained in the man page of ``flatpak-builder``.
 
 Manifests


### PR DESCRIPTION
flatpak-builder supports build systems like Meson etc. which doesn't abide to the rule.