### PR TITLE
French translation for flatpak documentation

### DIFF
--- a/po/fr/LC_MESSAGES/building-simple-apps.po
+++ b/po/fr/LC_MESSAGES/building-simple-apps.po
@@ -1,0 +1,106 @@
+# Flatpak Documentation
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../building-simple-apps.rst:2
+msgid "Building Simple Apps"
+msgstr "Construction d'applications simples"
+
+#: ../../building-simple-apps.rst:4
+msgid "The ``flatpak`` utility provides a simple set of commands for building and distributing applications. These allow creating new Flatpaks, into which new or existing applications can be built."
+msgstr "L'utilitaire ``flatpak`` fournit un ensemble simple de commandes pour construire et distribuer des applications. Celles-ci permettent la création de nouveaux Flatpaks, à l'intérieur desquels des applications nouvelles ou existantes peuvent être construites."
+
+#: ../../building-simple-apps.rst:6
+msgid "This section describes how to build a simple application which doesn't require any additional dependencies outside of the runtime it is built against. In order to complete the examples, you should have completed the steps in `Getting Setup <getting-setup.html>`_ first."
+msgstr "Cette section descrit comment construite une application simple qui ne nécessite aucune dépendence additionnelle en-dehors du runtime avec lequel elle a été construite. Afin de terminer les exemples, vous devrez avoir terminé les étapes de `Getting Setup <getting-setup.html>` d'abord."
+
+#: ../../building-simple-apps.rst:9
+msgid "Creating an app"
+msgstr "Création d'une application"
+
+#: ../../building-simple-apps.rst:11
+msgid "To create an application, the first step is to use the ``build-init`` command. This creates a directory into which an application can be built, which contains the correct directory structure and a metadata file which contains information about the app. The format for build-init is::"
+msgstr "Pour crééer une application, la première étape est d'utiliser la commande ``build-init``. Cela créé un répertoire dans lequel l'application peut être construit, qui contient la structure de répertoire adéquate and un fichier metadata qui contient les informations à propos de l'application. Le format pour build-init est::"
+
+#: ../../building-simple-apps.rst:15
+msgid "DIRECTORY is the name of the directory that will be created to contain the application"
+msgstr "DIRECTORY est le nom du répertoire qui sera créé pour contenir l'application"
+
+#: ../../building-simple-apps.rst:16
+msgid "APPNAME is the D-Bus name of the application"
+msgstr "APPNAME est le nom D-Bus de l'application"
+
+#: ../../building-simple-apps.rst:17
+msgid "SDK is the name of the SDK that will be used to build the application"
+msgstr "SDK est le nom du SDK qui sera utilisé pour construite l'application"
+
+#: ../../building-simple-apps.rst:18
+msgid "RUNTIME is the name of the runtime that will be required by the application"
+msgstr "RUNTIME est le nom du runtime qui sera requis par l'application"
+
+#: ../../building-simple-apps.rst:19
+msgid "BRANCH is typically the version of the SDK and runtime that will be used"
+msgstr "BRANCH is typiquement la version du SDK et du runtime qui sera utilisé"
+
+#: ../../building-simple-apps.rst:21
+msgid "For example, to build the GNOME Dictionary application using the GNOME 3.22 SDK, the command would look like::"
+msgstr "Par exemple, pour construire l'application GNOME dictionnaire en utilisant le SDK GNOME 3.22, la commande ressemblerait à::"
+
+#: ../../building-simple-apps.rst:25
+msgid "You can try this command now. In the next step we will build an application inside the resulting dictionary directory."
+msgstr "Vous pouvez essayer cette commande maintenant. À la prochaine étape nous construirons une application à l'intérieur du répertoire dictionnary résultant."
+
+#: ../../building-simple-apps.rst:28
+msgid "Building"
+msgstr "Construction"
+
+#: ../../building-simple-apps.rst:30
+msgid "``flatpak build`` is used to build an application using an SDK. This command is used to provide access to a sandbox. For example, the following will create a file inside the appdir sandbox (in the files directory)::"
+msgstr "``flatpak build`` est utilisé pour construire une application à l'aide d'un SDK. Cette commande est utilisé pour fournir un accès au bac à sable. Par exemple, la suivante va créer un fichier à l'intérieur du répertoire d'application du bac à sable (dans le répertoire fichiers)::"
+
+#: ../../building-simple-apps.rst:34
+msgid "(It is best to remove this file before continuing.)"
+msgstr "(Il est préférable de supprimer ce fichier avant de continuer.)"
+
+#: ../../building-simple-apps.rst:36
+msgid "The build command allows existing applications that have been made using the traditional configure, make, make install routine to be built inside a flatpak. You can try this using GNOME Dictionary. First, download the source files, extract them and switch to the resulting directory::"
+msgstr "La commande build permet aux applications existantes construite à l'aide des routines traditionnelles configure, make, make install à l'intérieur d'un flatpak. Vous pouvez essayer cela à l'aide de GNOME dictionnaire.  Premièrement, téléchargez les fichiers sources, extrayez-les et déplacez-vous dans le répertoire résultant::"
+
+#: ../../building-simple-apps.rst:42
+msgid "Then you can use the build command to build and install the source inside the dictionary directory that was previously made::"
+msgstr "Ainsi vous pouvez utiliser la commande build pour contruire et installer le code source dans le répertoire dictionnary qui a été précedemment créé::"
+
+#: ../../building-simple-apps.rst:49
+msgid "Since these are run in a sandbox, the compiler and other tools from the SDK are used to build and install, rather than those on the host system."
+msgstr "Comme ils sont exécutes dans un bac-à-sable, le compilateur et les autres outils provenant du SDK sont utilisés pour construire et installer, plutôt que ceux du système hôte."
+
+#: ../../building-simple-apps.rst:52
+msgid "Completing the build"
+msgstr "Compléter la construction"
+
+#: ../../building-simple-apps.rst:54
+msgid "Once an application has been built, the ``build-finish`` command needs to be used to specify access to different parts of the host, such as networking and graphics sockets. This command is also used to specify the command that is used to run the app (done by modifying the metadata file), and to create the application's exports directory. For example::"
+msgstr "Une fois l'application construite, la commande ``build-finish`` doit être utilisé pour spécifier l'accès aux différentes parties de l'hôte, comme les sockets réseaux et graphiques. Cette commande est aussi utilisé pour spécifier la commande utilisée pour exécuter l'application (effectué en modifiant le fichier metadata), et pour créer le répertoire des exports pour l'application. Par exemple::"
+
+#: ../../building-simple-apps.rst:58
+msgid "At this point you have successfully built a flatpak and prepared it to be run. To test the app, you need to export the Dictionary to a repository, add that repository and then install and run the app::"
+msgstr "À ce moment, vous avez construit un flatpak avec succès et l'avez préparé à être exécuté. Pour tester l'application, vous devez exporter Dictionnaire vers un dépôt, et ajouter ce dépôt et ensuite installer et exécuter l'application::"
+
+#: ../../building-simple-apps.rst:65
+msgid "This exports the app, creates a repository called tutorial-repo, installs the Dictionary application in the per-user installation area and runs it."
+msgstr "Cela exporte l'application, créé un dépôt appelé tutorial-repo, intalle l'application Dictionnaire dans une zone d'installation utilisateur, et l'exécute."

--- a/po/fr/LC_MESSAGES/command-reference.po
+++ b/po/fr/LC_MESSAGES/command-reference.po
@@ -1,0 +1,23 @@
+# Flatpak Documentation
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../command-reference.rst:2
+msgid "Command Reference"
+msgstr "Référence des commandes"
+

--- a/po/fr/LC_MESSAGES/distributing-applications.po
+++ b/po/fr/LC_MESSAGES/distributing-applications.po
@@ -1,0 +1,119 @@
+# Documentation Flatpak
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../distributing-applications.rst:2
+msgid "Distributing Applications"
+msgstr "Distribution d'applications"
+
+#: ../../distributing-applications.rst:4
+msgid "Flatpak provides several ways to distribute applications. The primary method is to host a repository. This is relatively simple (although there are some important details to be aware of) and allows application updates to be distributed."
+msgstr "Flatpak fournit plusieurs façon de distribuer des applications. La méthode principale est d'héberger un dépôt. Cela est relativement simple (néanmoins il y a certains détails important qu'il faut connaître) et permet aux mises à jour d'applications d'être distribuées."
+
+#: ../../distributing-applications.rst:6
+msgid "It is also possible to distribute Flatpaks as single file bundles, which can be useful in some situations."
+msgstr "Il est aussi possible de distribuer des flatpaks comme de simples paquets de fichiers, qui peut être utile dans certaines situations."
+
+#: ../../distributing-applications.rst:9
+msgid "Hosting a repository"
+msgstr "Héberger un dépôt"
+
+#: ../../distributing-applications.rst:11
+msgid "The previous sections of this guide describe how to generate repositories using ``build-export`` or ``flatpak-builder``. The resulting OSTree repository can be hosted on a web server for consumption by users."
+msgstr "La section précédente de ce guide décrit comment générer les dépôts à l'aide de ``build-export`` ou ``flatpak-builder``. Le dépôt OSTree en résultant peut être hébergé sur un serveur web pour usage par les utilisateurs."
+
+#: ../../distributing-applications.rst:14
+msgid "Important details"
+msgstr "Détails importants"
+
+#: ../../distributing-applications.rst:16
+msgid "OSTree repositories use archive-z2, meaning that they contain a single file for each file in the application. This means that pull operations will do a lot of HTTP requests. Since new requests are slow, it is important to enable HTTP keep-alive on the web server."
+msgstr "Les dépôts OSTree utilisent articles-z2, ce qui signifie qu'ils contiennent un seul fichier pour chaque fichier dans l'application. Les opérations de récupération feront donc beaucoup de requêtes HTTP. Comment la création de requête prend du temps, il est important d'activer la fonctionnalité HTTP keep-alive sur le serveur web."
+
+#: ../../distributing-applications.rst:18
+msgid "OSTree supports something called static deltas. These are single files in the repo that contains all the data needed to go between two revisions (or from nothing to a revision). Creating such deltas will take up more space on the server, but will make downloads much faster. This can be done with the ``build-update-repo --generate-static-deltas`` option."
+msgstr "OSTree supporte quelque-chose appelé deltas statiques. Ce sont de simples fichiers dans le dépôt qui contiennent toutes les données pour passer entre deux révisions (ou pour partir de zero). Créer de tels deltas prendra plus d'espace sur le serveur, mais accélerera les téléchargements. Cela peut être avec l'option ``build-update-repo --generate-static-deltas``."
+
+#: ../../distributing-applications.rst:21
+msgid "GPG signatures"
+msgstr "Signatures GPG"
+
+#: ../../distributing-applications.rst:23
+msgid "OSTree uses GPG to verify the identity of repositories. This requires that every commit to a repository uses a GPG signature, as well as when repository summary files are modified."
+msgstr "OSTree utilises GPG pour vérifier l'identité des dépôts. Cela requiert que chaque commit sur le dépôt utilise une signature GPG, ainsi que lorsque les fichiers sommaires du dépôt sont modifiés."
+
+#: ../../distributing-applications.rst:25
+msgid "To do this, a GPG key needs to be passed to the ``build-update-repo`` and ``build-export`` commands, as well as ``flatpak-builder`` if it is being used to modify or create a repository. (If you don't already have a key, `it is easy to generate one <https://help.github.com/articles/generating-a-new-gpg-key/>`_.) For example::"
+msgstr "Pour cela, une clé GPG doit être passée aux commandes ``build-update-repo`` et ``build-export``, ainsi qu'à ``flatpak-builder`` si elle est utilisée pour modifier ou créer un dépôt. (Si vous n'avez pas déjà une clé, `il est aisé d'en générer une <https://help.github.com/articles/generating-a-new-gpg-key/>`_.) Par exemple::"
+
+#: ../../distributing-applications.rst:29
+msgid "Here ``--gpg-homedir`` is optional, and allows specifying the home directory of the key to be used."
+msgstr "Ici ``--gpg-homedir`` est optionnel, et permet de spécifier le répertoire personnel de la clé à utiliser."
+
+#: ../../distributing-applications.rst:31
+msgid "Though it generally isn't recommended, it is possible to disable GPG verification of OSTree repositories. To do this, the ``--no-gpg-verify`` option can be used when a remote is added. GPG verification can also be disabled on an existing remote using ``flatpak remote-modify``."
+msgstr "Bien que ca ne soit pas généralement recommandé, il est possible de désactiver les vérifications GPG des dépôts OSTree. Pour cela, l'option ``--no-gpg-verify`` doit être passé quand le serveur distant est ajouté. La vérification GPG peut aussi être désactivée sur un serveur distant existant en utilisant ``flatpak remote-modify``."
+
+#: ../../distributing-applications.rst:33
+msgid "Note that it is necessary to become root in order to update a remote that does not have GPG verification enabled."
+msgstr "Notez qu'il est nécessaire de devenir root pour mettre à jour un serveur distant qui n'a pas la vérification GPG activé."
+
+#: ../../distributing-applications.rst:36
+msgid "Referring to repositories"
+msgstr "Se référer aux dépôts"
+
+#: ../../distributing-applications.rst:38
+msgid "A convenient way to point users to the repository containing your application is to provide a ``.flatpakrepo`` file that they can download and install. To install a ``.flatpakrepo`` file manually, use the command::"
+msgstr "Une façon pratique de diriger les utilisateurs vers le dépôt contenant votre application est de fournir un fichier ``.flatpakrepo`` qu'ils peuvent télécharger et installer. Pour installer un fichier ``.flatpakrepo`` manuellement, utilisez la commande::"
+
+#: ../../distributing-applications.rst:42
+msgid "A typical ``.flatpakrepo`` file looks like this::"
+msgstr "Un fichier ``.flatpakrepo`` typique ressemble à cela::"
+
+#: ../../distributing-applications.rst:49
+msgid "If your repository contains just a single application, it may be more convenient to use a .flatpakref file instead, which contains enough information to add the repository and install the application at the same time. To install a ``.flatpakref`` file manually, use the command::"
+msgstr "Si votre dépôt contient juste une seule application, il serait plus pratique d'utiliser un fichier .flatpakref à la place, qui contient assez d'information pour ajouter le dépôt et installer l'application en même temps.  Pour installer un fichier ``.flatpakref`` manuellement, utilisez la commande::"
+
+#: ../../distributing-applications.rst:53
+msgid "A typical ``.flatpakref`` file looks like this::"
+msgstr "Un fichier ``.flatpakref`` typique resulting à cela::"
+
+#: ../../distributing-applications.rst:64
+msgid "Note that the GPGKey key in these files contains the base64-encoded GPG key, which you can get with the following command::"
+msgstr "Notez que la clé GPGKey dans ces fichiers contient la clé GPG encodé en base64, que vous pouvez récupérer avec la commande suivante::"
+
+#: ../../distributing-applications.rst:69
+msgid "Single-file bundles"
+msgstr "Paquets de fichier-seul"
+
+#: ../../distributing-applications.rst:71
+msgid "Hosting a repository is the preferred way to distribute an application, but sometimes a single-file bundle that you can make available from a website or send as an email attachment is more convenient. Flatpak supports this with the ``build-bundle`` and ``build-import-bundle`` commands to convert an application in a repository to a bundle and back::"
+msgstr "Héberger un dépôt est la façon préféree pour distribuer une application, mais parfois un paquet de fichier-seul que vous pouvez rendre disponible à partir d'un site web ou à envoyer comme pièce-jointe d'un courrier électronique est plus pratique. Flatpak supporte cela avec les commandes ``build-bundle`` et ``build-import-bundle`` pour convertir une application d'un dépôt vers un paquet et inversement."
+
+#: ../../distributing-applications.rst:76
+msgid "For example, to create a bundle named `dictionary.flatpak` containing the GNOME dictionary app from the repository at ~/repositories/apps, run::"
+msgstr "Par exemple, pour créer un paquet nommé `dictionary.flatpak` contenant l'application GNOME dictionnary du dépôt situé à ~/repositories/apps, lancez::"
+
+#: ../../distributing-applications.rst:80
+msgid "To import the bundle into a repository on another machine, run::"
+msgstr "Pour importer un paquet dans un dépôt d'une autre machine, lancez::"
+
+#: ../../distributing-applications.rst:84
+msgid "Note that bundles have some drawbacks, compared to repositories. For example, distributing updates is much more convenient with a hosted repository, since users can just run ``flatpak update``."
+msgstr "Notez que les paquets ont certains désavantages comparés aux dépôts.  Par exemple, la distribution de mises à jour est plus pratique avec un dépôt hébergé, comme les utilisateur ont juste à lancer ``flatpak update``."
+

--- a/po/fr/LC_MESSAGES/elements-of-a-flatpak-app.po
+++ b/po/fr/LC_MESSAGES/elements-of-a-flatpak-app.po
@@ -1,0 +1,127 @@
+# Documentation Flatpak
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../elements-of-a-flatpak-app.rst:2
+msgid "Elements of a Flatpak Application"
+msgstr "Élements d'une application Flatpak"
+
+#: ../../elements-of-a-flatpak-app.rst:4
+msgid "Flatpak expects applications to follow standard Linux desktop conventions. These are supplemented with a small number of Flatpak-specific elements that are used to distribute, install and run applications."
+msgstr "Flatpak s'attend à ce que les applications suivent les conventions des environnements de bureau Linux standards. Ils sont complétées par un petit nombre d'éléments spécifiques à Flatpak qui sont utilisés pour distribuer, installer and lancer les applications."
+
+#: ../../elements-of-a-flatpak-app.rst:7
+msgid "Standard application elements"
+msgstr "Éléments d'une application standard"
+
+#: ../../elements-of-a-flatpak-app.rst:9
+msgid "The following are some of the Linux desktop conventions that are supported and expected by Flatpak. Application developers are encouraged to use them."
+msgstr "Les éléments suivants font partis des conventions des environnements de bureau Linux qui sont supportés et attendus par Flatpak. Les développeurs d'application sont encouragés à les utiliser."
+
+#: ../../elements-of-a-flatpak-app.rst:11
+msgid "`AppData <https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps>`_, for providing application information, such as descriptions and screenshots, that is used by app stores"
+msgstr "`AppData <https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps>`_, pour la fourniture des informations d'application, comme les descriptions et captures d'écran, qui sont utilisés dans les magasins d'application."
+
+#: ../../elements-of-a-flatpak-app.rst:12
+msgid "Application icons, as specified by the `Freedesktop icon theme specification <https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html>`_"
+msgstr "Icônes d'application, comme spécifié par la `spécification de thème d'icones Freedesktop <https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html>`_"
+
+#: ../../elements-of-a-flatpak-app.rst:13
+msgid "`D-Bus <https://www.freedesktop.org/wiki/Software/dbus/>`_, for interaction with the host"
+msgstr "`D-Bus <https://www.freedesktop.org/wiki/Software/dbus/>`_, pour l'intéraction avec l'hôte"
+
+#: ../../elements-of-a-flatpak-app.rst:14
+msgid "`Desktop files <https://standards.freedesktop.org/desktop-entry-spec/latest/>`_, for providing basic information about the application"
+msgstr "`Fichiers Desktop <https://standards.freedesktop.org/desktop-entry-spec/latest/>`_, pour la fourniture d'information basic à propos de l'application"
+
+#: ../../elements-of-a-flatpak-app.rst:15
+msgid "`PulseAudio <https://www.freedesktop.org/wiki/Software/PulseAudio/>`_, for sound"
+msgstr "`PulseAudio <https://www.freedesktop.org/wiki/Software/PulseAudio/>`_, pour le son"
+
+#: ../../elements-of-a-flatpak-app.rst:16
+msgid "`X11 <https://www.x.org/wiki/>`_ and `Wayland <https://wayland.freedesktop.org/>`_, for display"
+msgstr "`X11 <https://www.x.org/wiki/>`_ et `Wayland <https://wayland.freedesktop.org/>`_, pour l'affichage"
+
+#: ../../elements-of-a-flatpak-app.rst:19
+msgid "Application structure"
+msgstr "Structure d'une application"
+
+#: ../../elements-of-a-flatpak-app.rst:21
+msgid "When an application is built using flatpak, it is outputted with the following structure:"
+msgstr "Quand une application est construite à l'aide de flatpak, elle est … avec la structure suivante"
+
+#: ../../elements-of-a-flatpak-app.rst:23
+msgid "``metadata`` - a keyfile which provides information about the application"
+msgstr "``metadata`` - un fichier clé-valeur qui fournit une information à propos de l'application"
+
+#: ../../elements-of-a-flatpak-app.rst:24
+msgid "``/files`` - the files that make up the application, include source code and application data"
+msgstr "``/files`` - les fichier qui constitue l'application, dont le code source et les données de l'applicaton"
+
+#: ../../elements-of-a-flatpak-app.rst:25
+msgid "``/files/bin`` - application binaries"
+msgstr "``/files/bin`` - binaires de l'application"
+
+#: ../../elements-of-a-flatpak-app.rst:26
+msgid "``/export`` - files which the host environment needs access to, such as the application's AppData, .desktop file, icon and D-Bus service files"
+msgstr "``/export`` - les fichiers que l'environnement de l'hôte a besoin d'accéder, comme l'AppData de l'application, le fichier ``.desktop``, les fichiers du service D-Bus et des icônes"
+
+#: ../../elements-of-a-flatpak-app.rst:28
+msgid "All the files in the export directory must have the application ID as their prefix. For example:"
+msgstr "Tous les fichiers dans le répertoire ``/export`` doivent avoir un identifiant d'application comme préfixe. Par exemple:"
+ 
+#: ../../elements-of-a-flatpak-app.rst:30
+msgid "``org.gnome.App.appdata.xml``"
+msgstr "``org.gnome.App.appdata.xml``"
+
+#: ../../elements-of-a-flatpak-app.rst:31
+msgid "``org.gnome.App.desktop``"
+msgstr "``org.gnome.App.desktop``"
+
+#: ../../elements-of-a-flatpak-app.rst:32
+msgid "``org.gnome.App.png``"
+msgstr "``org.gnome.App.png``"
+
+#: ../../elements-of-a-flatpak-app.rst:33
+msgid "``org.gnome.App.service``"
+msgstr "``org.gnome.App.service``"
+
+#: ../../elements-of-a-flatpak-app.rst:35
+msgid "Naming files in this way prevents naming conflicts and ensures that system installed applications aren't overwritten."
+msgstr "Nommer les fichiers de cette façon évite les conflits de nommage et assure que les applications installées sur le système ne sont pas écrasées."
+
+#: ../../elements-of-a-flatpak-app.rst:37
+msgid "To name exported files in this way, either rename the relevant source files or use flatpak-builder to rename the files at build time (this is explained in more detail in `the section on flatpak-builder <flatpak-builder.html>`_)."
+msgstr "Pour nommer les fichiers exportés de cette façon, soit renommez les fichiers sources pertients ou utilisez ``flatpak-builder`` pour renommer les fichiers au moment de la construction (Ceci est plus amplement détaillé dans `la section sur flatpak-builder <flatpak-builder.html>`_).`"
+
+#: ../../elements-of-a-flatpak-app.rst:40
+msgid "Metadata files"
+msgstr "Fichier ``metadata``"
+
+#: ../../elements-of-a-flatpak-app.rst:42
+msgid "An application's ``metadata`` file provides information that allows flatpak to set up the sandbox for running the application. A typical metadata file looks like this::"
+msgstr "Un fichier ``metadata`` d'une application fournit l'information qui permet à Flatpak de déployer le bac à sable pour faire tourner l'application.  Un fichier ``metadata`` typique ressemble à cela::"
+
+#: ../../elements-of-a-flatpak-app.rst:63
+msgid "This specifies the name of the application, the runtime it requires, the SDK that it was built against and the command used to run it. It also specifies file and device access, sets certain environment variables (inside the application's sandbox, of course), and how it connects to the session bus. Details on how to change these metadata parameters are included in subsequent sections."
+msgstr "Cela spécifie le nom de l'application, quel runtime il nécessite, le SDK avec lequel il a été construit et la commande utilisé pour la lancer. Il spécifie aussi les accès aux fichiers et aux périphériques, définit certaines variables d'environnement (à l'intérieur du bac à sable de l'application bien sûr), et comment se connecter au bus de session. Les détails sur comment changer les paramètres méta-données sont inclus dans les sections suivantes."
+
+#: ../../elements-of-a-flatpak-app.rst:66
+msgid "While it is most common to encounter metadata files for applications, runtimes and extensions also have them."
+msgstr "Bien qu'il est plus commun de trouver des fichiers méta-données pour les applications, les runtimes et les extensions en possèdent aussi."
+

--- a/po/fr/LC_MESSAGES/flatpak-builder.po
+++ b/po/fr/LC_MESSAGES/flatpak-builder.po
@@ -1,0 +1,143 @@
+# Documentation Flatpak
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../flatpak-builder.rst:2
+msgid "Flatpak Builder"
+msgstr ""
+
+#: ../../flatpak-builder.rst:4
+msgid "Most applications require additional dependencies that aren't provided by their runtimes. Flatpak allows these dependencies to be bundled as part of the application itself. In order to do this, each dependency must be built inside the application build directory. The ``flatpak-builder`` tool automates this multi-step build process, making it possible to build all application modules with a single command."
+msgstr "La plupart des applications nécessite des dépendences additionnelles qui ne sont pas fournies avec leur runtime. Flatpak permet à ces dépendences d'être incluses à l'application elle-même. Afin de faire ceci, chaque dépendence doit être construit à l'intérieur du répertoire de construction. L'outil ``flatpak-builder`` automatise ce processus de plusieurs étapes, permettant de contruire tous les modules avec une seule commande."
+
+#: ../../flatpak-builder.rst:6
+msgid "flatpak-builder expects modules to be built in the standard manner by following what is called the `Build API <https://github.com/cgwalters/build-api/>`_. This requires modifying modules to follow the build API, if they don't already."
+msgstr "flatpak-builder s'attend que les modules soient construits de manière standard en suivant ce qui est appelé l'`API Build <https://github.com/cgwalters/build-api/>`_. Cela requiert la modification des modules pour qu'ils suivent l'API de construction, si ils ne le suivent pas déjà."
+
+#: ../../flatpak-builder.rst:8
+msgid "All json entities are explained in the man page of ``flatpak-builder``."
+msgstr "Toutes les entités json sont décrites dans la page de manuel de ``flatpak-builder``."
+
+#: ../../flatpak-builder.rst:11
+msgid "Manifests"
+msgstr "Manifestes"
+
+#: ../../flatpak-builder.rst:13
+msgid "The input to flatpak-builder is a JSON file that describes the parameters for building an application, as well as each of the modules to be bundled. This file is called the manifest. Module sources can be of several types, including ``.tar`` or ``.zip`` archives, Git or Bzr repositories, patch files or shell commands that are run."
+msgstr "L'entrée pour flatpak-builder est un fichier JSON descrivant les parametres pour construire une application, ainsi que les modules à intégrer.  Ce fichier est appelé le manifest. Les sources de modules peuvent être de plusieurs type, comme des archives ``.tar`` ou ``.zip``, des dépôts Git ou Bzr, des fichiers patch ou des commande shell à exécuter."
+
+#: ../../flatpak-builder.rst:15
+msgid "The GNOME Dictionary manifest is short, because the only module is the application itself::"
+msgstr "Le manifeste de Dictionnaire GNOME est court, parce que le seul module est l'application elle-même::"
+
+#: ../../flatpak-builder.rst:41
+msgid "As can be seen, this manifest includes basic information about the application before specifying a single .tar file to be downloaded and built. More complex manifests include a sequence of modules."
+msgstr "Comme vous pouvez voir, ce manifeste inclus les informations basiques à propos de l'application avant de spécifier un seul fichier .tar à télécharger et construire. Des manisfestes plus complexes include une suite de modules."
+
+#: ../../flatpak-builder.rst:44
+msgid "Cleanup"
+msgstr "Nettoyage"
+
+#: ../../flatpak-builder.rst:46
+msgid "After building has taken place, flatpak-builder performs a cleanup phase. This can be used to remove headers and development documentation, among other things. Two properties in the manifest file are used for this. First, a list of filename patterns can be included::"
+msgstr "Après que la construction ait été faite, flatpak-builder réalise une phase de nettoyage. Cela peut être utilisé pour supprimer les en-têtes et la documentation de développement, parmis d'autres choses. Deux propriétés dans le fichier manisfeste sont utilisés pour cela. Premièrement, une liste de patrons de nom de fichiers peut être incluse::"
+
+#: ../../flatpak-builder.rst:50
+msgid "The second cleanup property is a list of commands that are run during the cleanup phase::"
+msgstr "La seconde propriété de nettoyage est une liste de commandes qui sera lancée durant la phase de nettoyage::"
+
+#: ../../flatpak-builder.rst:54
+msgid "Cleanup properties can be set on a per-module basis, in which case only filenames that were created by that particular module will be matched."
+msgstr "Les propriétés de nettoyage peuvent être définies par module, dans ce cas seuls les fichiers créés dans ce module particulier seront ciblés."
+
+#: ../../flatpak-builder.rst:57
+msgid "File renaming"
+msgstr "Renommage de fichier"
+
+#: ../../flatpak-builder.rst:59
+msgid "Files that are exported by a flatpak must be prefixed using the application ID. If an application's source files are not named using this convention, flatpak-builder allows them to be renamed as part of the build process. To rename application icons, desktop files and AppData files, use the ``rename-icon``, ``rename-desktop-file`` and ``rename-appdata`` properties."
+msgstr "Les fichiers exportés par Flatpak doivent être préfixés avec l'identifiant d'application. Si les fichiers sources d'une application ne sont pas nommés suivant cette convention, flatpak-builder permet de les renommer durant le processus de construction. Pour renommer les fichiers icônes, desktop et AppData, utilisez les propriétés ``rename-icon``, ``rename-desktop-file`` et ``rename-appdata``." 
+
+#: ../../flatpak-builder.rst:62
+msgid "Splitting things up"
+msgstr "Séparer les choses"
+
+#: ../../flatpak-builder.rst:64
+msgid "By default, flatpak-builder splits off translations and debug information into separate .Locale and .Debug extensions. These 'standard' extension points are then added to the application's metadata file. You can turn this off with the ``separate-locales`` and ``no-debuginfo`` keys, but there shouldn't be any reason for it."
+msgstr "Par défaut, flatpak-builder séparer les traductions et les informations de débogage dans des extensions .Locale et .Debug. Ces extensions \"standards\" sont ensuite ajoutées dans le fichier de meta-données de l'application. Cela peut être désactivé avec les clés ``separate-locales`` et ``no-debuginfo``, mais il ne devrait pas y avoir de raisons valables pour le faire."
+
+#: ../../flatpak-builder.rst:66
+msgid "When flatpak-builder exports the build into a repository, it automatically includes the .Locale and .Debug extensions. If you do the exporting manually, don't forget to include them."
+msgstr "Quand flatpak-builder exporte le résultat de la construction dans un dépôt, il inclus automatiquement les extensions  .Locale et .Debug. Dans le cas d'un export manuel, n'oubliez pas de les inclure."
+
+#: ../../flatpak-builder.rst:69
+msgid "Example"
+msgstr "Exemple"
+
+#: ../../flatpak-builder.rst:71
+msgid "To try flatpak-builder yourself, create a file called ``org.gnome.Dictionary.json`` and paste the Dictionary manifest JSON from above into it. Then run the following command::"
+msgstr "Pour essayer flatpak-builder vous-même, créez un fichier nommé ``org.gnome.Dictionary.json`` et copiez le manifeste JSON de l'application dictionnaire ci-dessus dedans. Puis lancez la commande suivante::"
+
+#: ../../flatpak-builder.rst:75
+msgid "This will:"
+msgstr "Cela va:"
+
+#: ../../flatpak-builder.rst:77
+msgid "Create a new directory called dictionary2 (equivalent to using `flatpak build-init`)"
+msgstr "Créer un nouveau répertoire nommé dictionary2 (équivalent à `flatpak build-init`)"
+
+#: ../../flatpak-builder.rst:78
+msgid "Download and verify the Dictionary source code"
+msgstr "Télécharger et vérifier le code source de GNOME Dictionnaire"
+
+#: ../../flatpak-builder.rst:79
+msgid "Build and install the source code, using the SDK rather than the host system"
+msgstr "Construire et installer le code source à l'aide du SDK plutôt que de l'ĥôte système"
+
+#: ../../flatpak-builder.rst:80
+msgid "Finish the build, by setting permissions (in this case giving access to X and the network)"
+msgstr "Finir la construction en définissant les permissions (dans ce cas donnez accès au serveur X et au réseau)"
+
+#: ../../flatpak-builder.rst:81
+msgid "Create a new repository called repo (if it doesn't exist) and export the resulting build into it"
+msgstr "Créer un nouveau dépôt nommé repo (si il n'existe pas déjà) et exporter le résultat de la construction dedans"
+
+#: ../../flatpak-builder.rst:83
+msgid "flatpak-builder will also do some other useful things, like creating a separately installable debug runtime (called `org.gnome.Dictionary.Debug` in this case) and a separately installable translation runtime (called ``org.gnome.Dictionary.Locale``)."
+msgstr "flatpak-builder fera aussi d'autres choses utiles, tel que créer un runtime de débogage séparé (appelé ``org.gnome.Dictionary.Debug`` dans ce cas) and un runtime de traduction séparé (appelé ``org.gnome.Dictionary.Locale``)"
+
+#: ../../flatpak-builder.rst:85
+msgid "If you completed the tutorial in `Building Simple Apps <building-simple-apps.html>`_, you can update the Dictionary application you installed with the new version that was built and exported by flatpak-builder::"
+msgstr "Si vous terminez le tutoriel dans `Construction d'applications simples <building-simple-apps.html>`_, vous pouvez mettre à jour l'application Dictionnaire installée avec la nouvelle version qui a été construite et exportée par flatpak-builder::"
+
+#: ../../flatpak-builder.rst:89
+msgid "To check that the application has been successfully updated, you can compare the sha256 commit of the installed app with the commit ID that was printed by flatpak-builder::"
+msgstr "Pour vérifier que l'application a été mise à jour avec succès, vous pouvez comparer les commits sha256 de l'application installée avec celui affiché par flatpak-builder::" 
+
+#: ../../flatpak-builder.rst:94
+msgid "And finally, you can run the new version of the Dictionary app::"
+msgstr "Et finalement vous pouvez lancer la nouvelle version de l'application Dictionnaire::"
+
+#: ../../flatpak-builder.rst:99
+msgid "Example manifests"
+msgstr "Manifestes d'exemple"
+
+#: ../../flatpak-builder.rst:101
+msgid "A `complete manifest for GNOME Dictionary built from Git <https://git.gnome.org/browse/gnome-dictionary/tree/data/org.gnome.Dictionary.json>`_ is available, in addition to `manifests for a range of other GNOME applications <https://git.gnome.org/browse/gnome-apps-nightly/tree/>`_."
+msgstr "Un manifeste complete pour GNOME Dictionnaire construit à partir de Git <https://git.gnome.org/browse/gnome-dictionary/tree/data/org.gnome.Dictionary.json>`_ est disponible, en plus d'`autres manisfestes d'autres applications GNOME <https://git.gnome.org/browse/gnome-apps-nightly/tree/>`_."
+

--- a/po/fr/LC_MESSAGES/getting-setup.po
+++ b/po/fr/LC_MESSAGES/getting-setup.po
@@ -1,0 +1,71 @@
+# Documentation Flatpak
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../getting-setup.rst:2
+msgid "Getting Setup"
+msgstr "Mise en place"
+
+#: ../../getting-setup.rst:4
+msgid "Getting setup to build Flatpaks is quick and easy. First, it is necessary to have the ``flatpak`` and ``flatpak-builder`` packages installed on your system. These are available for most distributions, and the Flatpak website provides `details on how to get them <http://flatpak.org/getting.html>`_."
+msgstr "La mise en place pour construire des Flatpaks est rapide et simple.  Premièrement, il est nécessaire d'avoir les paquets ``flatpak`` et ``flatpak-builder`` installés sur votre système. Ils sont disponibles pour la plupart des distributions, et le site web Flatpak fournit les `détails pour les récuperer <http://flatpak.org/getting.html>`_."
+
+#: ../../getting-setup.rst:6
+msgid "Once flatpak has been installed, it is necessary to pick a runtime and install it, along with the matching SDK."
+msgstr "Une fois flatpak installé, il est nécessaire de choisir un runtime et de l'installer, avec le SDK correspondant."
+
+#: ../../getting-setup.rst:9
+msgid "Installing an SDK"
+msgstr "Installer un SDK"
+
+#: ../../getting-setup.rst:11
+msgid "An SDK is a special type of runtime that is used to build applications. Typically, an SDK is paired with a runtime that will be used by the application at runtime. For example the GNOME 3.22 SDK is used to build applications that use the GNOME 3.22 runtime."
+msgstr "Un SDK est un type spécial de runtime qui est utilisé pour contruire des applications. Typiquement, un SDK est lié avec un runtime qui sera utilisé par l'application à l'exécution Par exemple le SDK GNOME 3.22 est utilisé pour construire des applications qui utilisent le runtime GNOME 3.22."
+
+#: ../../getting-setup.rst:13
+msgid "The Flatpak website provides a `list of the available runtimes <http://flatpak.org/runtimes.html>`_. Once you have decided which one to use, getting setup is just a matter of installing it and its SDK."
+msgstr "Le site web de Flatpak fournit une `liste des runtimes disponibles <http://flatpak.org/runtimes.html>`_. Une fois décidé celui que vous allez utiliser, être en place est juste une question de l'installer et son SDK."
+
+#: ../../getting-setup.rst:15
+msgid "The examples in the rest of the Flatpak documentation use the GNOME 3.22 runtime and SDK. If you haven't installed these already, download the repository GPG key and then add the repository that contains the runtime and SDK::"
+msgstr "Les exemples dans la suite de la documentation Flatpak utilise le runtime et le SDK GNOME 3.22. Si vous ne les avez pas déjà installé, téléchargez la clé GPG du dépôt, ensuite ajoutez le dépôt qui contient le runtime et le SDK::"
+
+#: ../../getting-setup.rst:19
+msgid "You can now download and install the runtime and SDK::"
+msgstr "Vous pouvez maintenant télécharger et installer un runtime et un SDK::"
+
+#: ../../getting-setup.rst:23
+msgid "This same procedure can be used to install any other runtime and SDK."
+msgstr "La même procédure peut-être utilisé pour installer n'importe quel autre runtime et SDK."
+
+#: ../../getting-setup.rst:26
+msgid "Taking a look around"
+msgstr "Jeter un coup d'œil"
+
+#: ../../getting-setup.rst:28
+msgid "If this is the first time you've used Flatpak, it is a good time to try installing an application and having a look 'under the hood'. To do this, you need to add a repository that contains applications. We can do this using the gnome-apps repository to install gedit::"
+msgstr "Si c'est la première fois que vous utilisez Flatpak, c'est un bon moment pour tenter d'installer une application et jetez un œil à \"Sous le capot\". Pour faire cela, vous aurez à ajouter un dépôt qui contient les applications. Vous pouvez faire cela à l'aide du dépôt gnome-apps pour installer gedit::"
+
+#: ../../getting-setup.rst:33
+msgid "You can now use the following command to get a shell in the 'devel sandbox'::"
+msgstr "Vous pouvez mainteant utiliser la commande suivante pour obtenir un shell dans un 'bac à sable devel'::"
+
+#: ../../getting-setup.rst:37
+msgid "This gives you an environment which has the application bundle mounted in ``/app``, and the SDK it was built against mounted in ``/usr``. You can explore these two directories to see what a typical flatpak looks like, as well as what is included in the SDK."
+msgstr "Cela vous donne un environnement qui a le lot d'applications monté dans ``/app``, et le SDK avec lequel il a été construit monté dans ``/usr``. Vous pouvez explorer ces deux répertoires pour voir à quoi ressemble un flatpak typique, ainsi que ce qui est inclus dans le SDK."
+

--- a/po/fr/LC_MESSAGES/index.po
+++ b/po/fr/LC_MESSAGES/index.po
@@ -1,0 +1,38 @@
+# Documentation Flatpak 
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../index.rst:2
+msgid "Welcome to Flatpak's documentation!"
+msgstr "Bienvenue dans la documentation de Flatpak !"
+
+#: ../../index.rst:4
+msgid "These docs cover everything you need to know to build and distribute applications as Flatpaks. They contain a high-level introduction to Flatpak, tutorials and essential information on how to develop, build and distribute applications."
+msgstr "Cette documentation couvre tout ce que vous devez savoir pour contruire et distribuer des applications sous forme de Flatpaks. Elle contient une introduction de haut-niveau, des tutoriels et des informations essentielles sur comment développer, construire et distribuer des applications."
+
+#: ../../index.rst:6
+msgid "The docs are primarily intended for application developers and distributors. Their content is also relevant to those who have a general interest in Flatpak."
+msgstr "Cette documentation est premièrement à l'attention des développeurs et distributeurs d'applications. Son contenu est aussi pertinent à ceux qui souhaite posséder une connaissance générale de Flatpak."
+
+#: ../../index.rst:8
+msgid "If you are looking for information about how to install and use Flatpak applications, please refer to `the Flatpak website <http://flatpak.org>`_."
+msgstr "Si vous cherchez des informations sur comment installer et utiliser des applications Flatpak, veuillez vous référez au `site web Flatpak <http://flatpak.org>`_."
+
+#: ../../index.rst:11
+msgid "Contents"
+msgstr "Contenu"

--- a/po/fr/LC_MESSAGES/introduction.po
+++ b/po/fr/LC_MESSAGES/introduction.po
@@ -1,0 +1,210 @@
+# Documentation Flatpak
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../introduction.rst:2
+msgid "Introduction to Flatpak"
+msgstr "Introduction à Flatpak"
+
+#: ../../introduction.rst:4
+msgid "Flatpak is a technology for building, distributing, installing and running applications. It is primarily targeted at the Linux desktop, although it can also be used as the basis for application distribution in other contexts, such as embedded systems."
+msgstr "Flatpak est une technologie pour construire, distribuer, installer et exécuter des applications. Elle adresse principalement les environnements de bureaux Linux, néanmoins elle peut également être utilisée comme base de distribution d'applications dans d'autres contextes, comme les systèmes embarqués."
+
+#: ../../introduction.rst:6
+msgid "Flatpak has been designed and implemented with a number of goals:"
+msgstr "Flatpak a été conçu et mis en œuvre avec un nombre de buts:"
+
+#: ../../introduction.rst:8
+msgid "Allow applications to be installed on any Linux distribution."
+msgstr "Autoriser les applications a être installées sur n'importe quelle distribution Linux."
+
+#: ../../introduction.rst:9
+msgid "Provide consistent environments for applications, to facilitate testing and reduce bugs."
+msgstr "Fournir des environnements cohérents pour les applications, pour faciliter les tests et réduire les bogues."
+
+#: ../../introduction.rst:10
+msgid "Decouple applications from the operating system, so that applications don't depend on specific versions of each distribution."
+msgstr "Découpler les applications du système d'exploitation, ainsi les applications ne dépendent pas d'une version spécifique de chaque distribution."
+
+#: ../../introduction.rst:11
+msgid "Allow applications to bundle their own dependencies, so that they can use libraries that aren't provided by a Linux distribution, and so they can depend on specific versions or even patched versions of a library."
+msgstr "Permet aux applications de fournir leurs propres dépendences, ainsi ils peuvent utiliser des bibliothèques qui ne sont pas fournies par une distribution Linux, et dépendre de versions spécifiques voire même de versions patchées d'une bibliothèque."
+
+#: ../../introduction.rst:12
+msgid "Increase the security of Linux desktops, by isolating applications in sandboxes."
+msgstr "Augmenter la sécurité des environnements de bureau Linux, en isolant les applications dans des bacs à sable."
+
+#: ../../introduction.rst:14
+msgid "Flatpak makes it easy to take advantage of these features. If you haven't already, it is recommended that you try the `hello world <http://flatpak.org/hello-world.html>`_ example, as a way of getting started."
+msgstr "Flatpak rend l'accès facile à ces fonctions. Si ce n'est déjà fait, il est recommandé d'essayer l'exemple `hello world <http://flatpak.org/hello-world.html>`_, comme un moyen de débuter."
+
+#: ../../introduction.rst:16
+msgid "More information about Flatpak can be found on `flatpak.org <http://flatpak.org/>`_."
+msgstr "Plus d'informations à propos de Flatpak peuvent être trouver sur `flatpak.org <http://flatpak.org/>`_."
+
+#: ../../introduction.rst:19
+msgid "How it works"
+msgstr "Comment cela fonctionne"
+
+#: ../../introduction.rst:21
+msgid "Flatpak can be understood through a small number of key concepts. These also help to explain how it differs from traditional software packages."
+msgstr "Flatpak peut être compris à travers un petit nombre de concepts-clés. Ils aident aussi à expliquer comment il diffère des paquets logiciel traditionnels."
+
+#: ../../introduction.rst:26
+msgid "Runtimes"
+msgstr "Runtimes"
+
+#: ../../introduction.rst:28
+msgid "Runtimes provide the basic dependencies that are used by applications. Various runtimes are available, from more minimal (but more stable) Freedesktop runtimes, to larger runtimes produced by desktops like GNOME or KDE. (The `runtimes page <http://flatpak.org/runtimes.html>`_ on flatpak.org provides an overview of the runtimes that are currently available.)"
+msgstr "Les runtime fournissent les dépendences essentielles qui sont utilisées par les applications. Différents runtimes sont disponibles, du très minimal (mais plus stable) Freedesktop, à de plus gros produits par des environnements de bureaux comme GNOME ou KDE. La `page runtimes <http://flatpak.org/runtimes.html>`_ sur flatpak.org fournit un aperçu des runtimes qui sont actuellement disponibles.)"
+
+#: ../../introduction.rst:30
+msgid "Each application must be built against a runtime, and this runtime must be installed on a host system in order for the application to run. Users can install multiple different runtimes at the same time, including different versions of the same runtime."
+msgstr "Chaque application doit être construite à l'aide d'un runtime, et ce runtime doit être installé sur le système hôte afin que l'application se lance. Les utilisateurs peuvent installer plusieurs différents runtime en même temps, ainsi que différentes versions du même runtime."
+
+#: ../../introduction.rst:33
+msgid "Each runtime can be thought of as a ``/usr`` filesystem. Indeed, when an application is run, its runtime is mounted at ``/usr``."
+msgstr "Chaque runtime peut être vu comme un système de fichiers ``/usr``. En effet, quand une application est exécutée, son runtime est monté dans ``/usr``."
+
+#: ../../introduction.rst:36
+msgid "Bundled libraries"
+msgstr "Bibiothèques empaquetées"
+
+#: ../../introduction.rst:38
+msgid "If an application requires any dependencies that aren't in its runtime, they can be bundled along with the application itself. This allows applications to use dependencies that aren't available in a distribution, or to use a different version of a dependency from the one that's installed on the host."
+msgstr "Si une application requiert des dépendances qui n'est pas dans son runtime, elles peuvent intégrées au côté de l'application. Cela permet aux application d'utiliser des dépendences qui ne sont pas disponibles dans une distribution, ou d'utiliser une version différente de celle qui est installé sur l'hôte."
+
+#: ../../introduction.rst:41
+msgid "SDKs (Software Developer Kits)"
+msgstr "SDKs (kits de développement logiciel)"
+
+#: ../../introduction.rst:43
+msgid "An SDK is a runtime that includes the 'devel' parts which are not needed at runtime, such as build and packaging tools, header files, compilers and debuggers. Each application is built against an SDK, which is paired with a runtime (this is the runtime that will be used by the application at runtime)."
+msgstr "Un SDK est un runtime qui inclut les parties 'devel' qui ne sont pas nécessaires au runtime, comme si les outils de construction et d'empaquettage, les fichiers d'en-tête, les compilateurs et les débogueurs. Chaque application est construite avec ce SDK, qui est lié avec le runtime (ce runtime qui sera utilisé par l'application à son exécution)."
+
+#: ../../introduction.rst:46
+msgid "Extensions"
+msgstr "Extensions"
+
+#: ../../introduction.rst:48
+msgid "An extension is an optional add-on for a runtime or application. They are most commonly used to split out translations and debug info from runtimes. For example, ``org.freedesktop.Platform.Locale`` can be added to the ``org.freedesktop.Platform`` runtime in order to add translations."
+msgstr "Les extensions sont des modules optionnels pour un runtime ou une application. Elles sont utilisées pour séparer les traductions et les informations de debogage des runtimes. Par exemple ``org.freedesktop.Platform.Locale`` peut être ajouté au runtime ``org.freedesktop.Platform`` afin d'ajouter les traductions."
+
+#: ../../introduction.rst:51
+msgid "Sandboxes"
+msgstr "Bacs à sable"
+
+#: ../../introduction.rst:53
+msgid "With Flatpak, each app is built and run in an isolated environment. By default, the application can only 'see' itself and its runtime. Access to user files, network, graphics sockets, subsystems on the bus and devices have to be explicitly granted. (As will be described later, Flatpak provides several ways to do this.) Access to other things, such as other processes, is deliberately not possible."
+msgstr "Avec Flatpak, chaque application est construite et lancer dans un environnement isolé. Par défaut, l'application peut uniquement se \"voir\" elle-même et ses runtimes. L'accès aux fichiers utilisateurs, au réseau, aux sockets graphiques, aux sous-systèmes sur le bus et aux périphériques doit être explicitement permis. (Comme vous le verrez plus tard, Flatpak fournit plusieurs façons de faire cela.) L'accès à d'autres éléments, comme les autres processus, est délibéremment impossible."
+
+#: ../../introduction.rst:56
+msgid "The flatpak command"
+msgstr "La commande flatpak"
+
+#: ../../introduction.rst:58
+msgid "``flatpak`` is the command that is used to install, remove and update runtimes and applications. It can also be used to view what is currently installed, and has commands for building and distributing application bundles. ``flatpak --help`` provides a full list of available commands."
+msgstr "``flatpak`` est la commande utilisée pour installer, supprimer et mettre à jour les runtimes et les applications. Elle peut être utilisée pour voir ce qui est actuellement installé, et possède des commandes pour construire et distribuer des lots d'application. ``flatpak --help`` fournit la liste complète des commandes disponibles." 
+
+#: ../../introduction.rst:60
+msgid "Most flatpak commands are performed system-wide by default. To perform a command for the current user only, use the ``--user`` option. This allows runtimes and application bundles to be installed per-user, for instance."
+msgstr "La plupart des commandes flatpak sont effectuées au niveau système par défaut. Pour effectuer une commande au niveau utilisateur uniquement, utilisez l'option ``--user``. Cela permet aux paquets applicatifs et runtime d'être installé par utilisateur, par exemple."
+
+#: ../../introduction.rst:62
+msgid "For more information on flatpak commands, see the :doc:`command-reference`"
+msgstr "Pour plus d'informations sur les commandes flatpak, regardez la :doc:`command-reference`"
+
+#: ../../introduction.rst:65
+msgid "Identifiers"
+msgstr "Identifiants"
+
+#: ../../introduction.rst:67
+msgid "Flatpak identifies each application, runtime and SDK using a unique name, which is sometimes used as part of a name/arch/branch triple."
+msgstr "Flatpak identifie chaque application, runtime et SDK à l'aide de son nom unique, qui est parfois utilisé de la manière d'un triplet nom/architecture/branche."
+
+#: ../../introduction.rst:70
+msgid "Naming"
+msgstr "Nommage"
+
+#: ../../introduction.rst:72
+msgid "Flatpak names take the form of an inverse DNS address, such as ``com.company.App``. The final segment of this address is the object's name, and the preceding part is the domain that it belongs to. In order to prevent name conflicts, this domain should correspond to a DNS registered address. This means using a domain from a website, either for an application or an organization. For instance, if application ``App`` has its own website at ``app.com``, its Flatpak name would be ``com.app.App``. Multiple applications can belong to the same domain, such as ``org.organization.App1`` and ``org.organization.App2``."
+msgstr "la nomenclature Flatpak prend la forme d'une adresse DNS inversée, comme ``com.entreprise.Application``. Le segment final de cette adresse est le nom de l'objet, and la partie précédente est le domain auquel elle appartient.  Afin d'éviter les conflits de nom, ce domaine doit correspondre à une adresse DNS enregistrée. Cela signifie utiliser un domain d'une site web, soit pour une application ou une organisation. Par exemple, si une application ``App`` a son propre site web à ``app.com``, son nom Flatpak serait ``com.app.App``.  Plusieurs applications peuvent appartenir au même domaine, comme ``org.organization.App1`` et ``org.organization.App2``." 
+
+#: ../../introduction.rst:74
+msgid "If you do not have a registered domain for your application, it is easy to use a third party website to get one. For example, Github allows the creation of personal pages that can be used for this purpose. Here, a personal namespace of ``name.github.io`` could be used as the basis of application identifier ``io.github.name.App``."
+msgstr "Si vous n'avez pas un domaine enregistré pour votre application, il est facile d'utiliser le site d'une tierce-partie pour en avoir un. Par exemple, Github permet la création de pages personnelles qui peuvent être utilisées pour ce but. Ainsi, un espace de nom personnel ``name.github.io`` peut être utilisé comme base de l'identifiant de l'application ``io.github.name.App``." 
+
+#: ../../introduction.rst:76
+msgid "If an application provides a D-Bus service, the D-Bus service name is expected to be the same as the application name."
+msgstr "Quand une application fournit un service D-Bus, on s'attend que le nom de service D-Bus doit être le même que le nom d'application."
+
+#: ../../introduction.rst:79
+msgid "Identifier triples"
+msgstr "Triplets identifiants"
+
+#: ../../introduction.rst:81
+msgid "Many flatpak commands only require the name of an application, runtime or SDK. However, in some circumstances it is also necessary to specify the architecture and branch (branches allow a particular version to be specified). This is done using a name/arch/branch triple. For example: ``org.gnome.Sdk/x86_64/3.14`` or ``org.gnome.Builder/i386/master``."
+msgstr "Beaucoup de commandes flatpak requiert uniquement le nom d'une application, d'un runtime ou d'un SDK. Néanmoins, dans certaines circonstances il est également nécessaire de spécifier l'architecture et la branche (Les branches permettent de spécifier une version particulière). Cela est fait en utilisant un triplet nom/architecture/branch. Par exemple: ``org.gnome.Sdk/x86_64/3.14`` ou ``org.gnome.Builder/i386/master``."
+
+#: ../../introduction.rst:84
+msgid "Under the hood"
+msgstr "Sous le capot"
+
+#: ../../introduction.rst:86
+msgid "Flatpak uses a number of pre-existing technologies. It generally isn't necessary to be familiar with these in order to use Flatpak, although in some cases it might be useful. They include:"
+msgstr "Flatpak utilise un nombre de technologies déjà existantes. Il n'est généralement pas nécessaire d'être familier avec celles-ci pour utiliser Flatpak, néanmoins dans certains cas cela peut-etre utile. Elles inclues:"
+
+#: ../../introduction.rst:88
+msgid "The `bubblewrap <https://github.com/projectatomic/bubblewrap>`_ utility from `Project Atomic <http://www.projectatomic.io/>`_, which lets unprivileged users set up and run containers, using kernel features such as:"
+msgstr "L'utilitaire `bubblewrap <https://github.com/projectatomic/bubblewrap>`_ de `Projet Atomic <http://www.projectatomic.io/>`_, qui laisse les utilisateurs non-privilégies créer et lanceur des conteneurs, à l'aide des fonctions noyau tels que:"
+
+#: ../../introduction.rst:90
+msgid "Cgroups"
+msgstr "Groupes de contrôle (Cgroups)"
+
+#: ../../introduction.rst:91
+msgid "Namespaces"
+msgstr "Espaces de nom"
+
+#: ../../introduction.rst:92
+msgid "Bind mounts"
+msgstr ""
+
+#: ../../introduction.rst:93
+msgid "Seccomp rules"
+msgstr "Règles seccomp"
+
+#: ../../introduction.rst:95
+msgid "`systemd <https://www.freedesktop.org/wiki/Software/systemd/>`_ to set up cgroups for sandboxes"
+msgstr "`systemd <https://www.freedesktop.org/wiki/Software/systemd/>`_ pour définir les groupes de contrôle pour les bacs à sable" 
+
+#: ../../introduction.rst:96
+msgid "`D-Bus <https://www.freedesktop.org/wiki/Software/dbus/>`_, a well-established way to provide high-level APIs to applications"
+msgstr "`D-Bus <https://www.freedesktop.org/wiki/Software/dbus/>`_, une méthode bien établie pour fournir des API haut-niveaux aux applications"
+
+#: ../../introduction.rst:97
+msgid "The OCI format from the `Open Container Initiative <https://www.opencontainers.org/>`_, as a convenient transport format for single-file bundles"
+msgstr "Le format OCI de l'`initiative Open Container <https://www.opencontainers.org/>`_ comme un format de transport pratique pour les paquets en un seul fichier"
+
+#: ../../introduction.rst:98
+msgid "The `OSTree <https://ostree.readthedocs.io/en/latest/>`_ system for versioning and distributing filesystem trees"
+msgstr "Le système `OSTree <https://ostree.readthedocs.io/en/latest/>`_ pour le versionnage et la distribution d'arborescence de systèmes de fichers."
+
+#: ../../introduction.rst:99
+msgid "`Appstream <https://www.freedesktop.org/software/appstream/docs/>`_ metadata, to allow Flatpak applications to show up nicely in software-center applications"
+msgstr "Les méta-données `Appstream <https://www.freedesktop.org/software/appstream/docs/>`_, qui permettent les applications Flatpak d'apparaître proprement dans l'application software-center"
+

--- a/po/fr/LC_MESSAGES/working-with-the-sandbox.po
+++ b/po/fr/LC_MESSAGES/working-with-the-sandbox.po
@@ -1,0 +1,283 @@
+# Documentation Flatpak 
+# Copyright (C) 2017, Flatpak Team
+# This file is distributed under the same license as the Flatpak package.
+# Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>, 2017.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Flatpak \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-30 18:01+0200\n"
+"PO-Revision-Date: 2017-06-30 18:01+0200\n"
+"Last-Translator: Baptiste Mille-Mathias <baptiste.millemathias@gmail.com>\n"
+"Language: fr_FR"
+"Language-Team: fr_FR <traduc@traduc.org>
+\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../working-with-the-sandbox.rst:2
+msgid "Working with the Sandbox"
+msgstr "Travailler avec le bac à sable"
+
+#: ../../working-with-the-sandbox.rst:4
+msgid "One of Flatpak's main goals is to increase the security of desktop systems by isolating applications from one another. This is done using sandboxing and it means that, by default, a Flatpak has extremely limited access to the host environment. This includes:"
+msgstr "Un des buts principaux est d'améliorer la sécurité des environnements de bureaux en isolant les applications les unes des autres. C'est effectué à l'aide de bac à sable, et cela signifie que, par défaut, un Flatpak a des accès limités à l'environnement de l'hôte. Cela inclus:"
+
+#: ../../working-with-the-sandbox.rst:6
+msgid "No access to any host files except the runtime, the app and ``~/.var/app/$APPID``. Only the last of these is writable."
+msgstr "Pas d'accès à aucun des fichiers de l'hôte excepté le runtome, l'application et ``~/.var/app/$APPID``. Seul le dernier est autorisé en écriture."
+
+#: ../../working-with-the-sandbox.rst:7
+msgid "No access to the network."
+msgstr "Pas d'accès au réseau."
+
+#: ../../working-with-the-sandbox.rst:8
+msgid "No access to any device nodes (apart from ``/dev/null``, etc)."
+msgstr "Pas d'accès à aucun périphérique (à part ``/dev/null``, etc)."
+
+#: ../../working-with-the-sandbox.rst:9
+msgid "No access to processes outside the sandbox."
+msgstr "Pas d'accès aux processus en-dehors du bac à sable."
+
+#: ../../working-with-the-sandbox.rst:10
+msgid "Limited syscalls.  For instance, apps can't use nonstandard network socket types or ptrace other processes."
+msgstr "Appels systèmes (syscall) limités. Par exemple, les applications ne peuvent utiliser un type de socket réseau non-standard ou faire un ptrace des autres processus."
+
+#: ../../working-with-the-sandbox.rst:11
+msgid "Limited access to the session D-Bus instance - an app can only own its own name on the bus."
+msgstr "Accès limité à l'instance D-Bus de session - une application peut uniquement posséder son propre nom sur le bus."
+
+#: ../../working-with-the-sandbox.rst:12
+msgid "No access to host services like X, system D-Bus, or PulseAudio."
+msgstr "Pas d'accès aux services de l'hôte comme X, l'instance D-Bus système, ou PulseAudio."
+
+#: ../../working-with-the-sandbox.rst:14
+msgid "Most applications will need access to some of these resources in order to be useful, and Flatpak provides a number of ways to give an application access to them."
+msgstr "La plupart des applications auront besoin d'accéder à certaines de ces ressources afin d'être utile, et Flatpak fournit un nombre de façon pour donner à une application l'accès à ceux-ci."
+
+#: ../../working-with-the-sandbox.rst:16
+msgid "While there are no restrictions on which sandbox permissions an application can use, as good practice, it is recommended to use the minimum number of as permissions possible. Certain permissions, such as blanket access to the system bus (using the ``--socket=system-bus`` option) are strongly discouraged."
+msgstr "Bien qu'il n'y ait pas de restriction sur les permissions bac à sable qu'une application peut utiliser, comme bonne pratique, il est recommander d'utiliser le nombre minimum de permissions possibles. Certains permissions, comme l'accès général au bus système (à l'aide de l'option ``--socket=system-bus``) sont fortement découragés."
+
+#: ../../working-with-the-sandbox.rst:19
+msgid "Configuring sandbox permissions"
+msgstr "Configurer les permissions d'un bac à sable"
+
+#: ../../working-with-the-sandbox.rst:21
+msgid "Using the ``build-finish`` command is the simplest way to configure sandbox permissions. As was seen in a previous example, this can be used to add access to graphics sockets and the network::"
+msgstr "Utiliser la commande ``build-finish`` est le moyen le plus simple pour configurer les permissions d'un bac à sable. Comme vu dans l'exemple précédent, il peut être utilisé pour ajouter l'accès à la socket et au réseau::"
+
+#: ../../working-with-the-sandbox.rst:25
+msgid "These arguments translate into several properties in the application's metadata file::"
+msgstr "Ces arguments se traduisent en plusieurs propriétés dans le fichier de meta-données de l'application::"
+
+#: ../../working-with-the-sandbox.rst:37
+msgid "build-finish allows a whole range of resources to be added to an application. These options can also be passed to flatpak-builder as ``finish-args`` properties."
+msgstr "build-finish permet l'ajout de tout une gamme de ressources à une application. Ces options peuvent aussi être passées à flatpak-builder comme propriétés ``finish-args``."
+
+#: ../../working-with-the-sandbox.rst:39
+msgid "The table at the bottom of this page provides an overview of many sandbox permissions. The full list can also be viewed using ``flatpak build-finish --help``."
+msgstr "Le tableau au page de cette page fournit une vue d'ensemble de beaucoup de permissions des bac à sable. La liste complète peut aussi être vue à l'aide de ``flatpak build-finish --help``."
+
+#: ../../working-with-the-sandbox.rst:42
+msgid "Until a sandbox-compatible backend is available, access to dconf needs to be enabled using the following options::"
+msgstr "En attendant la disponibilité d'un backend compatible avec le bac à sable, l'accès à dconf nécessite d'être activé à l'aide des options suivantes::"
+
+#: ../../working-with-the-sandbox.rst:50
+msgid "Portals"
+msgstr "Portails"
+
+#: ../../working-with-the-sandbox.rst:52
+msgid "Portals are a mechanism through which applications can interact with the host environment from within a sandbox. In this way, they give additional abilities to interact with data, files and services without the need to add sandbox permissions."
+msgstr "Les portails sont des mécanismes à travers lesquels les applications peuvent intéragir avec l'environnement de l'hôte depuis le bac à sable. De cette façon, ils donnent des capacités additionnelles pour intéragir avec les données, les fichiers et les services sans la nécessité d'ajouter des permissions aux bacs à sables."
+
+#: ../../working-with-the-sandbox.rst:54
+msgid "Interface toolkits can implement transparent support for portals. If an application uses one of these toolkits, there is no additional work required to access them."
+msgstr "Des boîtes à outils d'interface graphique peuvent implémenter un support transparent des portails. Si une application utilise une des ces boîtes à outils, il n'y a pas de travail additionnel requies pour y accèder."
+
+#: ../../working-with-the-sandbox.rst:56
+msgid "Examples of capabilities that can be accessed through portals include:"
+msgstr "Exemples des capacités qui peuvent être accèdées à travers les portails inclus"
+
+#: ../../working-with-the-sandbox.rst:58
+msgid "Inhibit the user session from ending, suspending, idling or getting switched away"
+msgstr "Empêcher la session utilisateur de s'arrêter, se susprendre, "
+
+#: ../../working-with-the-sandbox.rst:59
+msgid "Network status information"
+msgstr "Information sur le statut réseau"
+
+#: ../../working-with-the-sandbox.rst:60
+msgid "Notifications"
+msgstr "Notifications"
+
+#: ../../working-with-the-sandbox.rst:61
+msgid "Open a URI"
+msgstr "Ouvrir une URI"
+
+#: ../../working-with-the-sandbox.rst:62
+msgid "Open files with a native file chooser dialog"
+msgstr "Ouvrir des fichiers avec la boîte de dialogue de sélection de fichier natif"
+
+#: ../../working-with-the-sandbox.rst:63
+msgid "Printing"
+msgstr "Impression"
+
+#: ../../working-with-the-sandbox.rst:64
+msgid "Screenshots"
+msgstr "Captures d'écran"
+
+#: ../../working-with-the-sandbox.rst:66
+msgid "Applications that aren't using a toolkit with support for portals can refer to the `xdg-desktop-portal API documentation <http://flatpak.org/xdg-desktop-portal/portal-docs.html>`_ for information on how to access them."
+msgstr "Les applications qui n'utilisent pas une boîte à outils avec le support des portails peuvent se référer à `la documentation de l'API xdg-desktop-portal <http://flatpak.org/xdg-desktop-portal/portal-docs.html>`_ pour les informations sur comment y accéder."
+
+#: ../../working-with-the-sandbox.rst:69
+msgid "Overriding sandbox permissions"
+msgstr "Passer outre les permissions d'un bac à sable"
+
+#: ../../working-with-the-sandbox.rst:71
+msgid "When developing an application, it can sometimes be useful to override a Flatpak's sandbox configuration. There are several ways to do this. One is to override them using ``flatpak run``, which accepts the same parameters as ``build-finish``. For example, this will let the Dictionary application see your home directory::"
+msgstr "Lors du développement d'une application, il peut être utile de passer outre la configuration bac à sable Flatpak. Il y a plusieurs façons de faire cela. Une des façons est d'utiliser ``flatpak run`` qui accepte les mêmes paramètres que ``build-finish``. Par exemple, cela permettra à l'application Dictionnaire de voir le répertoire personnel::" 
+
+#: ../../working-with-the-sandbox.rst:75
+msgid "``flatpak override`` can also be used to permanently override an application's permissions::"
+msgstr "``flatpak override`` peut aussi être utilisé pour outrepasser les permissions d'une application::"
+
+#: ../../working-with-the-sandbox.rst:80
+msgid "It is also possible to remove permissions using the same method. You can use the following command to see what happens when access to the filesystem is removed, for example::"
+msgstr "Il est aussi possible d'enlever des permissions avec la même méthode. Vous pouvez utiliser la commande suivante pour voir ce qui arrive quand l'accès au système de fichier est supprimé, par exemple::"
+
+#: ../../working-with-the-sandbox.rst:85
+msgid "Useful sandbox permissions"
+msgstr "Permissions bac à sable utiles"
+
+#: ../../working-with-the-sandbox.rst:87
+msgid "Flatpak provides an array of options for controlling sandbox permissions. The following are some of the most useful:"
+msgstr "Flatpak fournit un tableau d'options pour controller les permissions de bac à sable. Les suivants sont parmis les plus utiles:"
+
+#: ../../working-with-the-sandbox.rst:90
+msgid "--filesystem=host"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:90
+msgid "Access all files"
+msgstr "Accès à tous les fichiers"
+
+#: ../../working-with-the-sandbox.rst:91
+msgid "--filesystem=home"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:91
+msgid "Access the home directory"
+msgstr "Accès au répertoire personnel"
+
+#: ../../working-with-the-sandbox.rst:92
+msgid "--filesystem=home:ro"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:92
+msgid "Access the home directory, read-only"
+msgstr "Accès au répertoire personnel en lecture-seule"
+
+#: ../../working-with-the-sandbox.rst:93
+msgid "--filesystem=/some/dir --filesystem=~/other/dir"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:93
+msgid "Access paths"
+msgstr "Chemins d'accès"
+
+#: ../../working-with-the-sandbox.rst:94
+msgid "--filesystem=xdg-download"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:94
+msgid "Access the XDG download directory"
+msgstr "Accès au répertoire XDG Téléchargements"
+
+#: ../../working-with-the-sandbox.rst:95
+msgid "--nofilesystem=..."
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:95
+msgid "Undo some of the above"
+msgstr "Annule certaines options ci-dessus"
+
+#: ../../working-with-the-sandbox.rst:96
+msgid "--socket=x11 --share=ipc"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:96
+msgid "Show windows using X11 [#f1]_"
+msgstr "Affiche les fenêtres à l'aide de X11 [#f1]_"
+
+#: ../../working-with-the-sandbox.rst:97
+msgid "--device=dri"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:97
+msgid "OpenGL rendering"
+msgstr "Rendu OpenGL"
+
+#: ../../working-with-the-sandbox.rst:98
+msgid "--socket=wayland"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:98
+msgid "Show windows using Wayland"
+msgstr "Affiche les fenêtes à l'aide de Wayland"
+
+#: ../../working-with-the-sandbox.rst:99
+msgid "--socket=pulseaudio"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:99
+msgid "Play sounds using PulseAudio"
+msgstr "Joue les sons à l'aide de PulseAudio"
+
+#: ../../working-with-the-sandbox.rst:100
+msgid "--share=network"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:100
+msgid "Access the network [#f2]_"
+msgstr "Accès au réseau [#f2]_"
+
+#: ../../working-with-the-sandbox.rst:101
+msgid "--talk-name=org.freedesktop.secrets"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:101
+msgid "Talk to a named service on the session bus"
+msgstr "Parle à un service nommé sur le bus de session"
+
+#: ../../working-with-the-sandbox.rst:102
+msgid "--system-talk-name=org.freedesktop.GeoClue2"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:102
+msgid "Talk to a named service on the system bus"
+msgstr "Parle à un service nommé sur le bus système"
+
+#: ../../working-with-the-sandbox.rst:103
+msgid "--socket=system-bus"
+msgstr ""
+
+#: ../../working-with-the-sandbox.rst:103
+msgid "Unlimited access to all of D-Bus"
+msgstr "Accès illimité à tout D-Bus"
+
+#: ../../working-with-the-sandbox.rst:107
+msgid "Footnotes"
+msgstr "Bas de page"
+
+#: ../../working-with-the-sandbox.rst:108
+msgid "``–share=ipc`` means that the sandbox shares IPC namespace with the host. This is not necessarily required, but without it the X shared memory extension will not work, which is very bad for X performance."
+msgstr "``–share=ipc`` signifie que le bac à sable partage l'espace de nom IPC avec l'hôte. Ce n'est pas nécessairement requis, mais sans cela l'extension mémoire partagée de X ne fonctionnera pas, ce qui peut-être pénalisant pour les performance."
+
+#: ../../working-with-the-sandbox.rst:109
+msgid "Giving network access also grants access to all host services listening on abstract Unix sockets (due to how network namespaces work), and these have no permission checks. This unfortunately affects e.g. the X server and the session bus which listens to abstract sockets by default. A secure distribution should disable these and just use regular sockets."
+msgstr "Donner l'accès réseau donne aussi l'accès à tous les services de l'hôte qui écoutent sur une socket Unix abstraite (dû au fonctionnement des espaces de nom réseau), et n'ont pas de vérification de permissions. Cela affecte par exemple le serveur X and le bus de session qui écounte sur des sockets abstraits par défaut. Une distribution sûre devrait les désactiver et utiliser des sockets réguliers."
+


### PR DESCRIPTION
flatpak documentation translated in French.
it remains some sentences to translate because there is need to translate them because they contain only technical information (bug yet to be open for that)