### PR TITLE
Remove mention to systemd

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -92,7 +92,6 @@ Flatpak uses a number of pre-existing technologies. It generally isn't necessary
   * Bind mounts
   * Seccomp rules
 
-* `systemd <https://www.freedesktop.org/wiki/Software/systemd/>`_ to set up cgroups for sandboxes
 * `D-Bus <https://www.freedesktop.org/wiki/Software/dbus/>`_, a well-established way to provide high-level APIs to applications
 * The OCI format from the `Open Container Initiative <https://www.opencontainers.org/>`_, as a convenient transport format for single-file bundles
 * The `OSTree <https://ostree.readthedocs.io/en/latest/>`_ system for versioning and distributing filesystem trees


### PR DESCRIPTION
FAQ on http://flatpak.org/faq.html mentions that systemd is no longer required after version 0.6.10.