### PR TITLE
Fix CLI arguments

### DIFF
--- a/docs/working-with-the-sandbox.rst
+++ b/docs/working-with-the-sandbox.rst
@@ -86,25 +86,25 @@ Useful sandbox permissions
 
 Flatpak provides an array of options for controlling sandbox permissions. The following are some of the most useful:
 
-===============================================  ===========================================
---filesystem=host                                Access all files
---filesystem=home                                Access the home directory
---filesystem=home:ro                             Access the home directory, read-only
---filesystem=/some/dir --filesystem=~/other/dir  Access paths
---filesystem=xdg-download                        Access the XDG download directory
---nofilesystem=...                               Undo some of the above
---socket=x11 --share=ipc                         Show windows using X11 [#f1]_
---device=dri                                     OpenGL rendering
---socket=wayland                                 Show windows using Wayland
---socket=pulseaudio                              Play sounds using PulseAudio
---share=network                                  Access the network [#f2]_
---talk-name=org.freedesktop.secrets              Talk to a named service on the session bus
---system-talk-name=org.freedesktop.GeoClue2      Talk to a named service on the system bus
---socket=system-bus                              Unlimited access to all of D-Bus
-===============================================  ===========================================
+===================================================  ===========================================
+``--filesystem=host``                                Access all files
+``--filesystem=home``                                Access the home directory
+``--filesystem=home:ro``                             Access the home directory, read-only
+``--filesystem=/some/dir --filesystem=~/other/dir``  Access paths
+``--filesystem=xdg-download``                        Access the XDG download directory
+``--nofilesystem=...``                               Undo some of the above
+``--socket=x11 --share=ipc``                         Show windows using X11 [#f1]_
+``--device=dri``                                     OpenGL rendering
+``--socket=wayland``                                 Show windows using Wayland
+``--socket=pulseaudio``                              Play sounds using PulseAudio
+``--share=network``                                  Access the network [#f2]_
+``--talk-name=org.freedesktop.secrets``              Talk to a named service on the session bus
+``--system-talk-name=org.freedesktop.GeoClue2``      Talk to a named service on the system bus
+``--socket=system-bus``                              Unlimited access to all of D-Bus
+===================================================  ===========================================
 
 .. rubric:: Footnotes
 
-.. [#f1] ``–share=ipc`` means that the sandbox shares IPC namespace with the host. This is not necessarily required, but without it the X shared memory extension will not work, which is very bad for X performance.
+.. [#f1] ``--share=ipc`` means that the sandbox shares IPC namespace with the host. This is not necessarily required, but without it the X shared memory extension will not work, which is very bad for X performance.
 .. [#f2] Giving network access also grants access to all host services listening on abstract Unix sockets (due to how network namespaces work), and these have no permission checks. This unfortunately affects e.g. the X server and the session bus which listens to abstract sockets by default. A secure distribution should disable these and just use regular sockets.
 


### PR DESCRIPTION
The rst processor at Read The Docs transforms `--` (two hyphens) into `–` (en dash), which is a common web typography thing to do.

We don't want that here though, otherwise people can't just copy-paste from the docs.

Marking those strings as inline code fixes that.

In addition, one string was already marked as inline code, but was using the en dash in its source, which this commit also fixes.