### PR TITLE
Update the man pages to 0.10.1

### DIFF
--- a/docs/flatpak-docs.html
+++ b/docs/flatpak-docs.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><title>Flatpak Command Reference</title><link rel="stylesheet" type="text/css" href="docbook.css" /><meta name="generator" content="DocBook XSL Stylesheets Vsnapshot" /></head><body><div class="reference"><div class="titlepage"><div><div><h1 class="title"><a id="idm139821845219856"></a>Flatpak Command Reference</h1></div><div><p class="releaseinfo">Version 0.9.3</p></div></div><hr /></div><div class="partintro"><div></div><p>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><title>Flatpak Command Reference</title><link rel="stylesheet" type="text/css" href="docbook.css" /><meta name="generator" content="DocBook XSL Stylesheets V1.79.1" /></head><body><div class="reference"><div class="titlepage"><div><div><h1 class="title"><a id="idm1"></a>Flatpak Command Reference</h1></div><div><p class="releaseinfo">Version 0.10.1</p></div></div><hr /></div><div class="partintro"><div></div><p>
         Flatpak comes with a rich commandline interface.
-      </p><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="chapter"><a href="#idm139821845215056">Executables</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#flatpak">flatpak</a></span><span class="refpurpose"> — Build, install and run applications and runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-builder">flatpak-builder</a></span><span class="refpurpose"> — Help build application dependencies</span></dt></dl></dd><dt><span class="chapter"><a href="#idm139821843062944">Commands</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#flatpak-install">flatpak install</a></span><span class="refpurpose"> — Install an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-update">flatpak update</a></span><span class="refpurpose"> — Update an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-uninstall">flatpak uninstall</a></span><span class="refpurpose"> — Uninstall an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-list">flatpak list</a></span><span class="refpurpose"> — List installed applications and/or runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-info">flatpak info</a></span><span class="refpurpose"> — Show information about installed application and/or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-run">flatpak run</a></span><span class="refpurpose"> — Run an application or open a shell in a runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-override">flatpak override</a></span><span class="refpurpose"> — Override application requirements</span></dt><dt><span class="refentrytitle"><a href="#flatpak-make-current">flatpak make-current</a></span><span class="refpurpose"> — Make a specific version of an app current</span></dt><dt><span class="refentrytitle"><a href="#flatpak-enter">flatpak enter</a></span><span class="refpurpose"> — Enter an application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-export">flatpak document-export</a></span><span class="refpurpose"> — Export a file to a sandboxed application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-unexport">flatpak document-unexport</a></span><span class="refpurpose"> — Stop exporting a file</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-info">flatpak document-info</a></span><span class="refpurpose"> — Show information about exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-list">flatpak document-list</a></span><span class="refpurpose"> — List exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remotes">flatpak remotes</a></span><span class="refpurpose"> — List remote repositories</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-add">flatpak remote-add</a></span><span class="refpurpose"> — Add a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-modify">flatpak remote-modify</a></span><span class="refpurpose"> — Modify a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-delete">flatpak remote-delete</a></span><span class="refpurpose"> — Delete a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-ls">flatpak remote-ls</a></span><span class="refpurpose"> — Show available runtimes and applications</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-init">flatpak build-init</a></span><span class="refpurpose"> — Initialize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build">flatpak build</a></span><span class="refpurpose"> — Build in a directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-finish">flatpak build-finish</a></span><span class="refpurpose"> — Finalize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-export</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-bundle">flatpak build-bundle</a></span><span class="refpurpose"> — Create a single-file bundle from a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-import-bundle">flatpak build-import-bundle</a></span><span class="refpurpose"> — Import a file bundle into a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-sign</a></span><span class="refpurpose"> — Sign an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-update-repo">flatpak build-update-repo</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-commit-from">flatpak build-commit-from</a></span><span class="refpurpose"> — Create new commits based on existing one (possibly from another repository)</span></dt></dl></dd><dt><span class="chapter"><a href="#idm139821843047968">File Formats</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#flatpak-metadata">flatpak metadata</a></span><span class="refpurpose"> — Information about an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakrepo">flatpakrepo</a></span><span class="refpurpose"> — Reference to a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakref">flatpakref</a></span><span class="refpurpose"> — Reference to a remote for an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-manifest">flatpak manifest</a></span><span class="refpurpose"> — Information for building an application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote">flatpak remote</a></span><span class="refpurpose"> — Configuration for a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-installation">flatpak installation</a></span><span class="refpurpose"> — Configuration for an installation location</span></dt></dl></dd></dl></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="idm139821845215056"></a>Executables</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="refentrytitle"><a href="#flatpak">flatpak</a></span><span class="refpurpose"> — Build, install and run applications and runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-builder">flatpak-builder</a></span><span class="refpurpose"> — Help build application dependencies</span></dt></dl></div><div class="refentry"><a id="flatpak"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak — Build, install and run applications and runtimes</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak</code>  [OPTION...] {COMMAND}</p></div></div><div class="refsect1"><a id="idm139821837926528"></a><h2>Description</h2><p>
+      </p><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="chapter"><a href="#idm7">Executables</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#flatpak">flatpak</a></span><span class="refpurpose"> — Build, install and run applications and runtimes</span></dt></dl></dd><dt><span class="chapter"><a href="#idm352">Commands</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#flatpak-build-bundle">flatpak build-bundle</a></span><span class="refpurpose"> — Create a single-file bundle from a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-commit-from">flatpak build-commit-from</a></span><span class="refpurpose"> — Create new commits based on existing one (possibly from another repository)</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-export</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-finish">flatpak build-finish</a></span><span class="refpurpose"> — Finalize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-import-bundle">flatpak build-import-bundle</a></span><span class="refpurpose"> — Import a file bundle into a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-init">flatpak build-init</a></span><span class="refpurpose"> — Initialize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-sign</a></span><span class="refpurpose"> — Sign an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-update-repo">flatpak build-update-repo</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build">flatpak build</a></span><span class="refpurpose"> — Build in a directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-config">flatpak config</a></span><span class="refpurpose"> — Manage configuration</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-export">flatpak document-export</a></span><span class="refpurpose"> — Export a file to a sandboxed application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-info">flatpak document-info</a></span><span class="refpurpose"> — Show information about exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-list">flatpak document-list</a></span><span class="refpurpose"> — List exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-unexport">flatpak document-unexport</a></span><span class="refpurpose"> — Stop exporting a file</span></dt><dt><span class="refentrytitle"><a href="#flatpak-enter">flatpak enter</a></span><span class="refpurpose"> — Enter an application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-info">flatpak info</a></span><span class="refpurpose"> — Show information about installed application and/or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-install">flatpak install</a></span><span class="refpurpose"> — Install an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-list">flatpak list</a></span><span class="refpurpose"> — List installed applications and/or runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-make-current">flatpak make-current</a></span><span class="refpurpose"> — Make a specific version of an app current</span></dt><dt><span class="refentrytitle"><a href="#flatpak-override">flatpak override</a></span><span class="refpurpose"> — Override application requirements</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-add">flatpak remote-add</a></span><span class="refpurpose"> — Add a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-delete">flatpak remote-delete</a></span><span class="refpurpose"> — Delete a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-info">flatpak remote-info</a></span><span class="refpurpose"> — Show information about an application or runtime in a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-ls">flatpak remote-ls</a></span><span class="refpurpose"> — Show available runtimes and applications</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-modify">flatpak remote-modify</a></span><span class="refpurpose"> — Modify a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remotes">flatpak remotes</a></span><span class="refpurpose"> — List remote repositories</span></dt><dt><span class="refentrytitle"><a href="#flatpak-repo">flatpak repo</a></span><span class="refpurpose"> — Show information about a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-run">flatpak run</a></span><span class="refpurpose"> — Run an application or open a shell in a runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-search">flatpak search</a></span><span class="refpurpose"> — Search for applications and runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-uninstall">flatpak uninstall</a></span><span class="refpurpose"> — Uninstall an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-update">flatpak update</a></span><span class="refpurpose"> — Update an application or runtime</span></dt></dl></dd><dt><span class="chapter"><a href="#idm4290">File Formats</a></span></dt><dd><dl><dt><span class="refentrytitle"><a href="#flatpak-flatpakrepo">flatpakrepo</a></span><span class="refpurpose"> — Reference to a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakref">flatpakref</a></span><span class="refpurpose"> — Reference to a remote for an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-installation">flatpak installation</a></span><span class="refpurpose"> — Configuration for an installation location</span></dt><dt><span class="refentrytitle"><a href="#flatpak-metadata">flatpak metadata</a></span><span class="refpurpose"> — Information about an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote">flatpak remote</a></span><span class="refpurpose"> — Configuration for a remote</span></dt></dl></dd></dl></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="idm7"></a>Executables</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="refentrytitle"><a href="#flatpak">flatpak</a></span><span class="refpurpose"> — Build, install and run applications and runtimes</span></dt></dl></div><div class="refentry"><a id="flatpak"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak — Build, install and run applications and runtimes</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak</code>  [OPTION...] {COMMAND}</p></div></div><div class="refsect1"><a id="idm30"></a><h2>Description</h2><p>
             flatpak is a tool for managing applications and the runtimes
             they use. In the flatpak model, applications can be built and
             distributed independently from the host system they are used
@@ -33,7 +33,7 @@
             it uses are OSTree repositories and can be manipulated with the
             <span class="command"><strong>ostree</strong></span> utility. Installed runtimes and
             applications are OSTree checkouts.
-        </p></div><div class="refsect1"><a id="idm139821837912944"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+        </p></div><div class="refsect1"><a id="idm49"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
@@ -47,7 +47,7 @@
                     Print the supported arches in priority order and exit.
                 </p></dd><dt><span class="term"><code class="option">--gl-drivers</code></span></dt><dd><p>
                     Print the list of active gl drivers and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821837898672"></a><h2>Commands</h2><p>Commands for managing installed applications and runtimes:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a></span></dt><dd><p>
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm92"></a><h2>Commands</h2><p>Commands for managing installed applications and runtimes:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a></span></dt><dd><p>
                     Install an application or a runtime from a remote or bundle.
                 </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-update"><span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span></a></span></dt><dd><p>
                     Update an installed application or runtime.
@@ -57,6 +57,10 @@
                     List installed applications and/or runtimes.
                 </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-info"><span class="citerefentry"><span class="refentrytitle">flatpak-info</span>(1)</span></a></span></dt><dd><p>
                     Show information for an installed application or runtime.
+                </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-config"><span class="citerefentry"><span class="refentrytitle">flatpak-config</span>(1)</span></a></span></dt><dd><p>
+                    Manage flatpak configuration.
+                </p></dd></dl></div><p>Commands for finding applications and runtimes:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><a class="citerefentry" href="#flatpak-search"><span class="citerefentry"><span class="refentrytitle">flatpak-search</span>(1)</span></a></span></dt><dd><p>
+                    Search for applications and runtimes.
                 </p></dd></dl></div><p>Commands for running applications:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><a class="citerefentry" href="#flatpak-run"><span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span></a></span></dt><dd><p>
                     Run an application.
                 </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-override"><span class="citerefentry"><span class="refentrytitle">flatpak-override</span>(1)</span></a></span></dt><dd><p>
@@ -83,6 +87,8 @@
                     Delete a configured remote repository.
                 </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-remote-ls"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-ls</span>(1)</span></a></span></dt><dd><p>
                     List contents of a configured remote repository.
+                </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-remote-info"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-info</span>(1)</span></a></span></dt><dd><p>
+                    Show information about a ref in a configured remote repository.
                 </p></dd></dl></div><p>Commands for building applications:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a></span></dt><dd><p>
                     Initialize a build directory.
                 </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a></span></dt><dd><p>
@@ -101,215 +107,922 @@
                     Update the summary file in a repository.
                 </p></dd><dt><span class="term"><a class="citerefentry" href="#flatpak-build-commit-from"><span class="citerefentry"><span class="refentrytitle">flatpak-build-commit-from</span>(1)</span></a></span></dt><dd><p>
                     Create a new commit based on an existing ref.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821837837600"></a><h2>See also</h2><p>
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm316"></a><h2>Environment</h2><p>
+              Besides standard environment variables such as <code class="envar">XDG_DATA_DIRS</code> and
+              <code class="envar">XDG_DATA_HOME</code>, flatpak is consulting some of its own.
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="envar">FLATPAK_USER_DIR</code></span></dt><dd><p>
+                      The location of the per-user installation. If this is not set,
+                      <code class="filename">$XDG_DATA_HOME/flatpak</code> is used.
+                    </p></dd><dt><span class="term"><code class="envar">FLATPAK_SYSTEM_DIR</code></span></dt><dd><p>
+                      The location of the default system-wide installation. If this is not set,
+                      <code class="filename">/var/lib/flatpak</code> is used (unless overridden at build
+                      time by --localstatedir or --with-system-install-dir).
+                    </p></dd><dt><span class="term"><code class="envar">FLATPAK_CONFIG_DIR</code></span></dt><dd><p>
+                      The location of flatpak site configuration. If this is not set,
+                      <code class="filename">/etc/flatpak</code> is used (unless overridden at build
+                      time by --sysconfdir).
+                    </p></dd></dl></div></div><div class="refsect1"><a id="idm340"></a><h2>See also</h2><p>
                 <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
                 <a class="citerefentry" href="#ostree.repo"><span class="citerefentry"><span class="refentrytitle">ostree.repo</span>(5)</span></a>,
                 <a class="citerefentry" href="#flatpak-remote"><span class="citerefentry"><span class="refentrytitle">flatpak-remote</span>(5)</span></a>,
-            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-builder"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-builder — Help build application dependencies</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak-builder</code>  [OPTION...]  DIRECTORY   MANIFEST </p></div><div class="cmdsynopsis"><p><code class="command">flatpak-builder</code>   --run  [OPTION...]  DIRECTORY   MANIFEST   COMMAND </p></div><div class="cmdsynopsis"><p><code class="command">flatpak-builder</code>   --show-deps  [OPTION...]  MANIFEST </p></div></div><div class="refsect1"><a id="idm139821838095872"></a><h2>Description</h2><p>
-            <span class="command"><strong>flatpak-builder</strong></span> is a wrapper around the <span class="command"><strong>flatpak build</strong></span> command
-            that automates the building of applications and their dependencies. It is one option you can use
-            to build applications.
+            </p></div></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="idm352"></a>Commands</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="refentrytitle"><a href="#flatpak-build-bundle">flatpak build-bundle</a></span><span class="refpurpose"> — Create a single-file bundle from a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-commit-from">flatpak build-commit-from</a></span><span class="refpurpose"> — Create new commits based on existing one (possibly from another repository)</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-export</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-finish">flatpak build-finish</a></span><span class="refpurpose"> — Finalize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-import-bundle">flatpak build-import-bundle</a></span><span class="refpurpose"> — Import a file bundle into a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-init">flatpak build-init</a></span><span class="refpurpose"> — Initialize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-sign</a></span><span class="refpurpose"> — Sign an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-update-repo">flatpak build-update-repo</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build">flatpak build</a></span><span class="refpurpose"> — Build in a directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-config">flatpak config</a></span><span class="refpurpose"> — Manage configuration</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-export">flatpak document-export</a></span><span class="refpurpose"> — Export a file to a sandboxed application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-info">flatpak document-info</a></span><span class="refpurpose"> — Show information about exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-list">flatpak document-list</a></span><span class="refpurpose"> — List exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-unexport">flatpak document-unexport</a></span><span class="refpurpose"> — Stop exporting a file</span></dt><dt><span class="refentrytitle"><a href="#flatpak-enter">flatpak enter</a></span><span class="refpurpose"> — Enter an application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-info">flatpak info</a></span><span class="refpurpose"> — Show information about installed application and/or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-install">flatpak install</a></span><span class="refpurpose"> — Install an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-list">flatpak list</a></span><span class="refpurpose"> — List installed applications and/or runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-make-current">flatpak make-current</a></span><span class="refpurpose"> — Make a specific version of an app current</span></dt><dt><span class="refentrytitle"><a href="#flatpak-override">flatpak override</a></span><span class="refpurpose"> — Override application requirements</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-add">flatpak remote-add</a></span><span class="refpurpose"> — Add a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-delete">flatpak remote-delete</a></span><span class="refpurpose"> — Delete a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-info">flatpak remote-info</a></span><span class="refpurpose"> — Show information about an application or runtime in a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-ls">flatpak remote-ls</a></span><span class="refpurpose"> — Show available runtimes and applications</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-modify">flatpak remote-modify</a></span><span class="refpurpose"> — Modify a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remotes">flatpak remotes</a></span><span class="refpurpose"> — List remote repositories</span></dt><dt><span class="refentrytitle"><a href="#flatpak-repo">flatpak repo</a></span><span class="refpurpose"> — Show information about a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-run">flatpak run</a></span><span class="refpurpose"> — Run an application or open a shell in a runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-search">flatpak search</a></span><span class="refpurpose"> — Search for applications and runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-uninstall">flatpak uninstall</a></span><span class="refpurpose"> — Uninstall an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-update">flatpak update</a></span><span class="refpurpose"> — Update an application or runtime</span></dt></dl></div><div class="refentry"><a id="flatpak-build-bundle"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-bundle — Create a single-file bundle from a local repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-bundle</code>  [OPTION...]  LOCATION   FILENAME   NAME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm378"></a><h2>Description</h2><p>
+            Creates a single-file named  FILENAME 
+            for the application (or runtime) named   NAME 
+            in the repository at   LOCATION . If
+            a   BRANCH  is specified, this branch of
+            the application is used.
+            
         </p><p>
-            The goal of <span class="command"><strong>flatpak-builder</strong></span> is to push as much knowledge about how to build modules to
-            the individual upstream projects. It does this by assuming that the modules adhere to the Build API specified
-            at https://github.com/cgwalters/build-api. This essentially  means that it follows the <span class="command"><strong>./configure
-            &amp;&amp; make &amp;&amp; make install</strong></span> scheme with an optional autogen script. If the upstream
-            does not adhere to the API you can make it do so by adding patches and extra files.
+            The format of the bundle file is that of an ostree static delta
+            (against an empty base) with some flatpak specific metadata for
+            the application icons and appdata.
+        </p></div><div class="refsect1"><a id="idm386"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Export a runtime instead of an application.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The arch to create a bundle for.
+                </p></dd><dt><span class="term"><code class="option">--repo-url=URL</code></span></dt><dd><p>
+                    The URL for the repository from which the
+                    application can be updated. Installing the
+                    bundle will automatically configure a remote
+                    for this URL.
+                </p></dd><dt><span class="term"><code class="option">--runtime-repo=URL</code></span></dt><dd><p>
+                  The URL for a .flatpakrepo file that contains
+                  the information about the repository that supplies
+                  the runtimes required by the app.
+                </p></dd><dt><span class="term"><code class="option">--gpg-keys=FILE</code></span></dt><dd><p>
+                    Add the GPG key from FILE (use - for stdin).
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings.
+                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
+                    Export to an OCI image instead of a Flatpak bundle.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm444"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-import-bundle"><span class="citerefentry"><span class="refentrytitle">flatpak-build-import-bundle</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-commit-from"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-commit-from — Create new commits based on existing one (possibly from another repository)</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-commit-from</code>  [OPTION...]  DST-REPO   DST-REF... </p></div></div><div class="refsect1"><a id="idm490"></a><h2>Description</h2><p>
+            Creates new commits on the  DST-REF 
+            branch in the   DST-REPO , with the
+            contents (and most of the metadata) taken from another
+            branch, either from another repo, or from another branch in
+            the same repository.
+            
         </p><p>
-            An invocation of <span class="command"><strong>flatpak-builder</strong></span> proceeds in these stages, each being specified
-            in detail in json format in   MANIFEST :
-            </p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: bullet; "><li class="listitem" style="list-style-type: disc"><p>Download all sources</p></li><li class="listitem" style="list-style-type: disc"><p>Initialize the application directory with <span class="command"><strong>flatpak build-init</strong></span></p></li><li class="listitem" style="list-style-type: disc"><p>Build and install each module with <span class="command"><strong>flatpak build</strong></span></p></li><li class="listitem" style="list-style-type: disc"><p>Clean up the final build tree by removing unwanted files and e.g. stripping binaries</p></li><li class="listitem" style="list-style-type: disc"><p>Finish the application directory with <span class="command"><strong>flatpak build-finish</strong></span></p></li></ul></div><p>
+            This command is very useful when you want to maintain a branch
+            with a clean history that has no unsigned or broken commits.
+            For instance, you can import the head from a different repository
+            from an automatic builder when you've verified that it worked.
+            The new commit will have no parents or signatures from the
+            autobuilder, and can be properly signed with the official
+            key.
+        </p></div><div class="refsect1"><a id="idm496"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--src-repo=SRC-REPO</code></span></dt><dd><p>
+                    The (local) repository to pull the source branch from. Defaults to the
+                    destination repository.
+                </p></dd><dt><span class="term"><code class="option">--src-ref=SRC-REF</code></span></dt><dd><p>
+                    The branch to use as the source for the new commit. Defaults to the same
+                    as the destination ref, which is useful only if a different source repo
+                    has been specified.
+                </p></dd><dt><span class="term"><code class="option">--untrusted</code></span></dt><dd><p>
+                    The source repostory is not trusted, all objects are copied (not hardlinked) and
+                    all checksums are verified.
+                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--subject=SUBJECT</code></span></dt><dd><p>
+                    One line subject for the commit message. If not specified, will be taken from the source commit.
+                </p></dd><dt><span class="term"><code class="option">-b</code>, </span><span class="term"><code class="option">--body=BODY</code></span></dt><dd><p>
+                    Full description for the commit message. If not specified, will be taken from the source commit.
+                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
+                    Run appstream-builder and to update the appstream branch after build.
+                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
+                    Don't update the summary file after the new commit is added. This means
+                    the repository will not be useful for serving over http until build-repo-update
+                    has been run. This is useful is you want to do multiple repo operations before
+                    finally updating the summary.
+                </p></dd><dt><span class="term"><code class="option">--force</code></span></dt><dd><p>
+                    Create new commit even if the content didn't change from the existing branch head.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm578"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-export ~/repos/gnome-calculator/ ~/build/gnome-calculator/ org.gnome.Calculator</strong></span>
+        </p><pre class="programlisting">
+Commit: 9d0044ea480297114d03aec85c3d7ae3779438f9d2cb69d717fb54237acacb8c
+Metadata Total: 605
+Metadata Written: 5
+Content Total: 1174
+Content Written: 1
+Content Bytes Written: 305
+</pre></div><div class="refsect1"><a id="idm583"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-sign"><span class="citerefentry"><span class="refentrytitle">flatpak-build-sign</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-export — Create a repository from a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-export</code>  [OPTION...]  LOCATION   DIRECTORY  [BRANCH]</p></div></div><div class="refsect1"><a id="idm630"></a><h2>Description</h2><p>
+            Creates or updates a repository with an application build.
+             LOCATION  is the location of the
+            repository.   DIRECTORY  must be a
+            finalized build directory. If   BRANCH 
+            is not specified, it is assumed to be "master".
+        </p><p>
+            If  LOCATION  exists, it is assumed to
+            be an OSTree repository, otherwise a new OSTree repository is
+            created at this location. The repository can be inspected with
+            the <span class="command"><strong>ostree</strong></span> tool.
+        </p><p>
+            The contents of  DIRECTORY  are committed
+            on the branch with name <code class="literal">app/APPNAME/ARCH/BRANCH</code>,
+            where ARCH is the architecture of the runtime that the application
+            is using. A commit filter is used to enforce that only the contents
+            of the <code class="filename">files/</code> and <code class="filename">export/</code>
+            subdirectories and the <code class="filename">metadata</code> file are included
+            in the commit, anything else is ignored.
+        </p><p>
+            The build-update-repo command should be used to update repository
+            metadata whenever application builds are added to a repository.
+        </p></div><div class="refsect1"><a id="idm646"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--subject=SUBJECT</code></span></dt><dd><p>
+                    One line subject for the commit message.
+                </p></dd><dt><span class="term"><code class="option">-b</code>, </span><span class="term"><code class="option">--body=BODY</code></span></dt><dd><p>
+                    Full description for the commit message.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    Specify the architecture component of the branch to export. Only host compatible architectures can be specified.
+                </p></dd><dt><span class="term"><code class="option">--exclude=PATTERN</code></span></dt><dd><p>
+                    Exclude files matching PATTERN from the commit.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--include=PATTERN</code></span></dt><dd><p>
+                    Don't exclude files matching PATTERN from the commit, even if they match the --export patterns.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--metadata=FILENAME</code></span></dt><dd><p>
+                  Use the specified filename as metadata in the exported app instead of
+                  the default file (called <code class="filename">metadata</code>). This is useful
+                  if you want to commit multiple things from a single build tree, typically
+                  used in combination with --files and --exclude.
+                </p></dd><dt><span class="term"><code class="option">--files=SUBDIR</code></span></dt><dd><p>
+                  Use the files in the specified subdirectory as the file contents, rather
+                  than the regular <code class="filename">files</code> directory.
+                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
+                    Run appstream-builder and to update the appstream branch after build.
+                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
+                    Don't update the summary file after the new commit is added. This means
+                    the repository will not be useful for serving over http until build-repo-update
+                    has been run. This is useful is you want to do multiple repo operations before
+                    finally updating the summary.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Export a runtime instead for an app (this uses the usr subdir as files).
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm742"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-export ~/repos/gnome-calculator/ ~/build/gnome-calculator/ org.gnome.Calculator</strong></span>
+        </p><pre class="programlisting">
+Commit: 9d0044ea480297114d03aec85c3d7ae3779438f9d2cb69d717fb54237acacb8c
+Metadata Total: 605
+Metadata Written: 5
+Content Total: 1174
+Content Written: 1
+Content Bytes Written: 305
+</pre></div><div class="refsect1"><a id="idm747"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-sign"><span class="citerefentry"><span class="refentrytitle">flatpak-build-sign</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-finish"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-finish — Finalize a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-finish</code>  [OPTION...]  DIRECTORY </p></div></div><div class="refsect1"><a id="idm792"></a><h2>Description</h2><p>
+            Finalizes a build directory, to prepare it for exporting.
+             DIRECTORY  is the name of the directory.
+        </p><p>
+            The result of this command is that desktop files, icons and
+            D-Bus service files from the <code class="filename">files</code> subdirectory
+            are copied to a new <code class="filename">export</code> subdirectory. In the
+            <code class="filename">metadata</code> file, the command key is set in the
+            [Application] group, and the supported keys in the [Environment]
+            group are set according to the options.
+        </p><p>
+            You should review the exported files and the application metadata
+            before creating and distributing an application bundle.
+        </p><p>
+            It is an error to run build-finish on a directory that has not
+            been initialized as a build directory, or has already been finalized.
+        </p></div><div class="refsect1"><a id="idm802"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--command=COMMAND</code></span></dt><dd><p>
+                    The command to use. If this option is not specified,
+                    the first executable found in <code class="filename">files/bin</code>
+                    is used.
+                </p></dd><dt><span class="term"><code class="option">--require-version=MAJOR.MINOR.MICRO</code></span></dt><dd><p>
+                    Require this version of later of flatpak to install/update to this build.
+                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
+                    Share a subsystem with the host session. This updates
+                    the [Context] group in the metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
+                    Don't share a subsystem with the host session. This updates
+                    the [Context] group in the metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
+                    Expose a well known socket to the application. This updates
+                    the [Context] group in the metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
+                    Don't expose a well known socket to the application. This updates
+                    the [Context] group in the metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
+                    Expose a device to the application. This updates
+                    the [Context] group in the metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
+                    Don't expose a device to the application. This updates
+                    the [Context] group in the metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
+                    Allow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                 </p><p>
+                    The <code class="code">devel</code> feature allows the application to
+                    access certain syscalls such as <code class="code">ptrace()</code>, and
+                <code class="code">perf_event_open()</code>.
+                </p><p>
+                    The <code class="code">multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code class="code">x86_64</code>
+                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
+                    well.
+                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
+                    Disallow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--filesystem=FS</code></span></dt><dd><p>
+                    Allow the application access to a subset of the filesystem.
+                    This updates the [Context] group in the metadata.
+                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
+                    path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
+                    The optional :ro suffix indicates that the location will be read-only.
+                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
+                    Remove access to the specified subset of the filesystem from
+                    the application. This overrides to the Context section from the
+                    application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    an absolute path, or a homedir-relative path like ~/dir.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
+</p><pre class="programlisting">
+[Policy subsystem]
+key=v1;v2;
+</pre><p>
+                </p><p>
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Remove generic policy option. This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
+                    Set an environment variable in the application.
+                    This updates the [Environment] group in the metadata.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
 
-            After this you will end up with a build of the application in   DIRECTORY , which you can
-            export to a repository with the <span class="command"><strong>flatpak build-export</strong></span> command. If you use the <code class="option">--repo</code>
-            option, flatpak-builder will do the export for you at the end of the build process. When flatpak-builder does the
-            export, it also stores the manifest that was used for the build in /app/manifest.json. The manifest is 'resolved',
-            i.e. git branch names are replaced by the actual commit IDs that were used in the build.
+                    This updates the [Session Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the session bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This updates the [Session Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+                    This updates the [System Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This updates the [System Bus Policy] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
+                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
+                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    allowing that location to be used for persistent data.
+                    This updates the [Context] group in the metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--runtime=RUNTIME</code>, </span><span class="term"><code class="option">--sdk=SDK</code></span></dt><dd><p>
+                  Change the runtime or sdk used by the app to the specified partial ref. Unspecified parts
+                  of the ref are taken from the old values or defaults.
+                </p></dd><dt><span class="term"><code class="option">--metadata=GROUP=KEY[=VALUE]</code></span></dt><dd><p>
+                  Set a generic key in the metadata file. If value is left out it will
+                  be set to "true".
+                </p></dd><dt><span class="term"><code class="option">--extension=NAME=VARIABLE[=VALUE]</code></span></dt><dd><p>
+                  Add extension point info.
+                </p></dd><dt><span class="term"><code class="option">--extension-priority=VALUE</code></span></dt><dd><p>
+                  Set the priority (library override order) of the extension point.
+                  Only useful for extensions. 0 is the default, and higher value means higher
+                  priority.
+                </p></dd><dt><span class="term"><code class="option">--extra-data=NAME:SHA256:DOWNLOAD-SIZE:INSTALL-SIZE:URL</code></span></dt><dd><p>
+                    Adds information about extra data uris to the app. These will be downloaded
+                    and verified by the client when the app is installed and placed in the
+                    /app/extra directory. You can also supply an /app/bin/apply_extra script
+                    that will be run after the files are downloaded.
+                </p></dd><dt><span class="term"><code class="option">--no-exports</code></span></dt><dd><p>
+                    Don't look for exports in the build.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm974"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-finish /build/my-app --socket=x11 --share=ipc</strong></span>
+        </p><pre class="programlisting">
+Exporting share/applications/gnome-calculator.desktop
+Exporting share/dbus-1/services/org.gnome.Calculator.SearchProvider.service
+More than one executable
+Using gcalccmd as command
+Please review the exported files and the metadata
+</pre></div><div class="refsect1"><a id="idm979"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-import-bundle"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-import-bundle — Import a file bundle into a local repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-import-bundle</code>  [OPTION...]  LOCATION   FILENAME </p></div></div><div class="refsect1"><a id="idm1016"></a><h2>Description</h2><p>
+            Imports a bundle from a file named  FILENAME 
+            into the repository at   LOCATION .
         </p><p>
-            At each of the above steps flatpak caches the result, and if you build the same file again, it will start
-            at the first step where something changes. For instance the first version controlled source that had
-            new commits added, or the first module where some changes to the  MANIFEST  file caused
-            the build environment to change. This makes flatpak-builder very efficient for incremental builds.
-        </p></div><div class="refsect1"><a id="idm139821839950096"></a><h2>Manifest</h2><p>The manifest file is a json file whose format is described in detail in its own manual page.</p></div><div class="refsect1"><a id="idm139821837690544"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+            The format of the bundle file is that generated by build-bundle.
+        </p></div><div class="refsect1"><a id="idm1022"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ref=REF</code></span></dt><dd><p>
+                    Override the ref specified in the bundle.
+                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
+                    Import an OCI image instead of a Flatpak bundle.
+                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
+                    Run appstream-builder and to update the appstream branch after build.
+                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
+                    Don't update the summary file after the new commit is added. This means
+                    the repository will not be useful for serving over http until build-repo-update
+                    has been run. This is useful is you want to do multiple repo operations before
+                    finally updating the summary.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1080"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-bundle"><span class="citerefentry"><span class="refentrytitle">flatpak-build-bundle</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-init"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-init — Initialize a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-init</code>  [OPTION...]  DIRECTORY   APPNAME   SDK   RUNTIME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm1120"></a><h2>Description</h2><p>
+            Initializes a directory for building an application.
+             DIRECTORY  is the name of the directory.
+              APPNAME  is the application id of the app
+            that will be built.
+              SDK  and   RUNTIME 
+            specify the sdk and runtime that the application should be built
+            against and run in.
+        </p><p>
+            The result of this command is that a <code class="filename">metadata</code>
+            file is created inside the given directory. Additionally, empty
+            <code class="filename">files</code> and <code class="filename">var</code> subdirectories
+            are created.
+        </p><p>
+            It is an error to run build-init on a directory that has already
+            been initialized as a build directory.
+        </p></div><div class="refsect1"><a id="idm1132"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to use.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--var=RUNTIME</code></span></dt><dd><p>
+                    Initialize var from the named runtime.
+                </p></dd><dt><span class="term"><code class="option">-w</code>, </span><span class="term"><code class="option">--writable-sdk</code></span></dt><dd><p>
+                    Initialize /usr with a copy of the sdk, which is writable during flatpak build. This can be used
+                    if you need to install build tools in /usr during the build. This is stored in the
+                    <code class="filename">usr</code> subdirectory of the app dir, but will not be part of the final
+                    app.
+                </p></dd><dt><span class="term"><code class="option">--tag=TAG</code></span></dt><dd><p>
+                    Add a tag to the metadata file.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--sdk-extension=EXTENSION</code></span></dt><dd><p>
+                    When using --writable-sdk, in addition to the sdk, also install the specified extension.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--sdk-dir</code></span></dt><dd><p>
+                    Specify a custom subdirectory to use instead of <code class="filename">usr</code> for --writable-sdk.
+                </p></dd><dt><span class="term"><code class="option">--update</code></span></dt><dd><p>
+                    Re-initialize the sdk and var, don't fail if already initialized.
+                </p></dd><dt><span class="term"><code class="option">--base=APP</code></span></dt><dd><p>
+                    Initialize the application with files from another specified application.
+                </p></dd><dt><span class="term"><code class="option">--base-version=VERSION</code></span></dt><dd><p>
+                    Specify the version to use for --base. If not specified, will default to
+                    "master".
+                </p></dd><dt><span class="term"><code class="option">--base-extension=EXTENSION</code></span></dt><dd><p>
+                    When using --base, also install the specified extension from the app.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--type=TYPE</code></span></dt><dd><p>
+                    This can be used to build different types of things. The default
+                    is "app" which is a regular app, but "runtime" creates a runtime
+                    based on an existing runtime, and "extension" creates an extension
+                    for an app or runtime.
+                </p></dd><dt><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1214"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-init /build/my-app org.gnome.Sdk org.gnome.Platform 3.16</strong></span>
+        </p></div><div class="refsect1"><a id="idm1218"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-sign — Sign an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-sign</code>  [OPTION...]  LOCATION   ID  [BRANCH]</p></div></div><div class="refsect1"><a id="idm1256"></a><h2>Description</h2><p>
+            Signs the commit for a specified application or runtime in
+            a local repository.   LOCATION  is
+            the location of the repository.   ID  is the name of the application, or
+            runtime if --runtime is specified. If   BRANCH  is not specified, it is
+            assumed to be "master".
+        </p><p>
+            Applications can also be signed during build-export, but
+            it is sometimes useful to add additional signatures later.
+        </p></div><div class="refsect1"><a id="idm1263"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Sign a runtime instead of an app.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to use.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1311"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build-sign --gpg-sign=D8BA6573DDD2418027736F1BC33B315E53C1E9D6 /some/repo org.my.App</strong></span>
+        </p></div><div class="refsect1"><a id="idm1315"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-update-repo"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-update-repo — Create a repository from a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-update-repo</code>  [OPTION...]  LOCATION </p></div></div><div class="refsect1"><a id="idm1351"></a><h2>Description</h2><p>
+            Updates repository metadata for the repository at
+             LOCATION . This command generates
+            an OSTree summary file that lists the contents of the repository.
+            The summary is used by flatpak repo-contents and other commands
+            to display the contents of remote repositories.
+        </p><p>
+            After this command,  LOCATION  can be
+            used as the repository location for flatpak add-repo, either by
+            exporting it over http, or directly with a file: url.
+        </p></div><div class="refsect1"><a id="idm1357"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--redirect-url=URL</code></span></dt><dd><p>
+                    Redirect this repo to a new URL.
+                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
+                    A title for the repository, e.g. for display in a UI.
+                    The title is stored in the repository summary.
+                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
+                    A default branch for the repository, mainly for use in a UI.
+                </p></dd><dt><span class="term"><code class="option">--gpg-import=FILE</code></span></dt><dd><p>
+                    Import a new default GPG public key from the
+                    given file.
+                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
+                    Sign the commit with this GPG key.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
+                    GPG Homedir to use when looking for keyrings
+                </p></dd><dt><span class="term"><code class="option">--generate-static-deltas</code></span></dt><dd><p>
+                  Generate static deltas for all references. This generates from-empty and
+                  delta static files that allow for faster download.
+                </p></dd><dt><span class="term"><code class="option">--prune</code></span></dt><dd><p>
+                    Remove unreferenced objects in repo.
+                </p></dd><dt><span class="term"><code class="option">--prune-depth</code></span></dt><dd><p>
+                    Only keep at most this number of old versions for any particular ref. Default is -1 which means infinite.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1430"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-repo-contents"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-contents</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build — Build in a directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build</code>  [OPTION...]  DIRECTORY  [COMMAND [ARG...]]</p></div></div><div class="refsect1"><a id="idm1468"></a><h2>Description</h2><p>
+            Runs a build command in a directory.  DIRECTORY 
+            must have been initialized with <span class="command"><strong>flatpak build-init</strong></span>.
+        </p><p>
+            The sdk that is specified in the <code class="filename">metadata</code> file
+            in the directory is mounted at <code class="filename">/usr</code> and the
+            <code class="filename">files</code> and <code class="filename">var</code> subdirectories
+            are mounted at <code class="filename">/app</code> and <code class="filename">/var</code>,
+            respectively. They are writable, and their contents are preserved between
+            build commands, to allow accumulating build artifacts there.
+        </p></div><div class="refsect1"><a id="idm1480"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Use the non-devel runtime that is specified in the application metadata instead of the devel runtime.
+                </p></dd><dt><span class="term"><code class="option">-p</code>, </span><span class="term"><code class="option">--die-with-parent</code></span></dt><dd><p>
+                    Kill the build process and all children when the launching process dies.
+                </p></dd><dt><span class="term"><code class="option">--bind-mount=DEST=SOURCE</code></span></dt><dd><p>
+                    Add a custom bind mount in the build namespace. Can be specified multiple times.
+                </p></dd><dt><span class="term"><code class="option">--build-dir=PATH</code></span></dt><dd><p>
+                    Start the build in this directory (default is in the current directory).
+                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
+                    Share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
+                    Don't share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
+                    Expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
+                    Don't expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
+                    Expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
+                    Don't expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
+                    Allow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                 </p><p>
+                    The <code class="code">devel</code> feature allows the application to
+                    access certain syscalls such as <code class="code">ptrace()</code>, and
+                <code class="code">perf_event_open()</code>.
+                </p><p>
+                    The <code class="code">multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code class="code">x86_64</code>
+                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
+                    well.
+                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
+                    Disallow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--filesystem=FILESYSTEM[:ro|:create]</code></span></dt><dd><p>
+                    Allow the application access to a subset of the filesystem.
+                    This overrides to the Context section from the application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
+                    path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
+                    The optional :ro suffix indicates that the location will be read-only.
+                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
+                    Remove access to the specified subset of the filesystem from
+                    the application. This overrides to the Context section from the
+                    application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    an absolute path, or a homedir-relative path like ~/dir.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--with-appdir</code></span></dt><dd><p>
+                  Expose and configure access to the per-app storage directory in $HOME/.var/app. This is
+                  not normally useful when building, but helps when testing built apps.
+                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
+</p><pre class="programlisting">
+[Policy subsystem]
+key=v1;v2;
+</pre><p>
+                </p><p>
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Remove generic policy option. This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
+                    Set an environment variable in the application.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well-known name NAME on the system bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well-known name NAME on the system bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
+                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
+                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    allowing that location to be used for persistent data.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--sdk-dir=DIR</code></span></dt><dd><p>
+                  Normally if there is a <code class="filename">usr</code> directory in the build dir, this is used
+                  for the runtime files (this can be created by --writable-sdk or --type=runtime arguments
+                  to build-init). If you specify --sdk-dir this directoryname will be used instead.
+                  Use this if you passed --sdk-dir to build-init.
+                </p></dd><dt><span class="term"><code class="option">--readonly</code></span></dt><dd><p>
+                  Mount the normally writable destination directories read-only. This can
+                  be useful if you want to run something in the sandbox but guarantee that
+                  it doesn't affect the build results. For example tests.
+                </p></dd><dt><span class="term"><code class="option">--metadata=FILE</code></span></dt><dd><p>
+                  Use the specified filename as metadata in the exported app instead of
+                  the default file (called <code class="filename">metadata</code>). This is useful
+                  if you build multiple things from a single build tree (such as both a
+                  platform and a sdk).
+                </p></dd><dt><span class="term"><code class="option">--log-session-bus</code></span></dt><dd><p>
+                    Log session bus traffic. This can be useful to see what access you need to allow in
+                    your D-Bus policy.
+                </p></dd><dt><span class="term"><code class="option">--log-system-bus</code></span></dt><dd><p>
+                    Log system bus traffic. This can be useful to see what access you need to allow in
+                    your D-Bus policy.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1655"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak build /build/my-app rpmbuild my-app.src.rpm</strong></span>
+        </p></div><div class="refsect1"><a id="idm1659"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-config"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-config — Manage configuration</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak config</code>  [OPTION...]  KEY   VALUE </p></div></div><div class="refsect1"><a id="idm1696"></a><h2>Description</h2><p>
+            Show and modify current configuration
+        </p></div><div class="refsect1"><a id="idm1699"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--list</code></span></dt><dd><p>
+                    Print all keys and their values
+                </p></dd><dt><span class="term"><code class="option">--set</code></span></dt><dd><p>
+                    Set key KEY to VALUE
+                </p></dd><dt><span class="term"><code class="option">--unset</code></span></dt><dd><p>
+                    Unset key KEY
+                </p></dd><dt><span class="term"><code class="option">--get</code></span></dt><dd><p>
+                  Print value of KEY.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Configure per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Configure system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Configure the system-wide installation
+                    specified by  NAME  among those defined in
+                    <code class="filename">/etc/flatpak/installations.d/</code>. Using
+                      --installation=default  is equivalent to using
+                      --system .
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1749"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak config --set language sv;en;fi</strong></span>
+        </p></div><div class="refsect1"><a id="idm1753"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-export — Export a file to a sandboxed application</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-export</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm1780"></a><h2>Description</h2><p>
+            Creates a document id for a local file that can be exposed to
+            sandboxed applications, allowing them access to files that they
+            would not otherwise see. The exported files are exposed in a
+            fuse filesystem at /run/user/$UID/doc/.
+        </p><p>
+            This command also lets you modify the per-application
+            permissions of the documents, granting or revoking access
+            to the file on a per-application basis.
+        </p></div><div class="refsect1"><a id="idm1784"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-u</code>, </span><span class="term"><code class="option">--unique</code></span></dt><dd><p> Don't reuse an existing document id
+                for the file.  This makes it safe to later remove the
+                document when you're finished with it.
+                </p></dd><dt><span class="term"><code class="option">-t</code>, </span><span class="term"><code class="option">--transient</code></span></dt><dd><p>
+                  The document will only exist for the length of
+                  the session. This is useful for temporary grants.
+                </p></dd><dt><span class="term"><code class="option">-n</code>, </span><span class="term"><code class="option">--noexist</code></span></dt><dd><p>
+                  Don't require the file to exist already.
+                </p></dd><dt><span class="term"><code class="option">-a</code>, </span><span class="term"><code class="option">--app=APPID</code></span></dt><dd><p>
+                  Grant read access to the specified application. The
+                  --allow and --forbid options can be used to grant
+                  or remove additional privileges.
+                  This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--allow-read</code></span></dt><dd><p>
+                  Grant read access to the applications specified with --app.
+                  This defaults to TRUE.
+                </p></dd><dt><span class="term"><code class="option">--forbid-read</code></span></dt><dd><p>
+                  Revoke read access for the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-w</code>, </span><span class="term"><code class="option">--allow-write</code></span></dt><dd><p>
+                  Grant write access to the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">--forbid-write</code></span></dt><dd><p>
+                  Revoke write access for the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--allow-delete</code></span></dt><dd><p>
+                  Grant the ability to remove the document from the document portal to the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">--forbid-delete</code></span></dt><dd><p>
+                  Revoke the ability to remove the document from the document portal from the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-g</code>, </span><span class="term"><code class="option">--allow-grant-permission</code></span></dt><dd><p>
+                  Grant the ability to grant further permissions to the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">--forbid-grant-permission</code></span></dt><dd><p>
+                  Revoke the ability to grant further permissions for the applications specified with --app.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1883"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak document-export --app=org.gnome.GEdit ~/test.txt</strong></span>
+        </p><pre class="programlisting">
+/run/user/1000/doc/e52f9c6a/test.txt
+</pre></div><div class="refsect1"><a id="idm1888"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-unexport"><span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-info"><span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-list"><span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-info"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-info — Show information about exported files</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-info</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm1924"></a><h2>Description</h2><p>
+            Shows information about an exported file, such as the
+            document id, the fuse path, the original location in the
+            filesystem, and the per-application permissions.
+        </p><p>
+            FILE can either be a file in the fuse filesystem at /run/user/$UID/doc/,
+            or a file anywhere else.
+        </p></div><div class="refsect1"><a id="idm1928"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
                     Print version information and exit.
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    Specify the machine architecture to build for. If no architecture is specified, the host architecture will be automatically detected. Only host compatible architectures can be specified.
-                </p></dd><dt><span class="term"><code class="option">--disable-cache</code></span></dt><dd><p>
-                    Don't look at the existing cache for a previous build, instead always rebuild modules.
-                </p></dd><dt><span class="term"><code class="option">--disable-rofiles-fuse</code></span></dt><dd><p>
-                    Disable the use of rofiles-fuse to optimize the cache use via hardlink checkouts.
-                </p></dd><dt><span class="term"><code class="option">--disable-download</code></span></dt><dd><p>
-                     Don't download any sources. This only works if some version of all sources are downloaded
-                     already. This is useful if you want to guarantee that no network i/o is done. However, the
-                     build will fail if some source is not locally available.
-                </p></dd><dt><span class="term"><code class="option">--disable-updates</code></span></dt><dd><p>
-                  Download missing sources, but don't update local mirrors of version control repos. This is useful
-                  to rebuild things but without updating git or bzr repositories from the remote repository.
-                </p></dd><dt><span class="term"><code class="option">--run</code></span></dt><dd><p>
-                  Run a command in a sandbox based on the build dir. This starts flatpak build, with some extra
-                  arguments to give the same environment as the build, and the same permissions the final app
-                  will have. The command to run must be the last argument passed to
-                  flatpak-builder, after the directory and the manifest.
-                </p></dd><dt><span class="term"><code class="option">--build-shell=MODULENAME</code></span></dt><dd><p>
-                  Extract and prepare the sources for the named module, and then start
-                  a shell in a sandbox identical to the one flatpak-builder would use for buildng the module.
-                  This is useful to debug a module.
-                </p></dd><dt><span class="term"><code class="option">--show-deps</code></span></dt><dd><p>
-                  List all the (local) files that the manifest depends on.
-                </p></dd><dt><span class="term"><code class="option">--download-only</code></span></dt><dd><p>
-                     Exit successfully after downloading the required sources.
-                </p></dd><dt><span class="term"><code class="option">--build-only</code></span></dt><dd><p>
-                     Don't do the cleanup and finish stages, which is useful if you
-                     want to build more things into the app.
-                </p></dd><dt><span class="term"><code class="option">--finish-only</code></span></dt><dd><p>
-                     Only do the cleanup, finish and export stages, picking up
-                     where a --build-only command left off.
-                </p></dd><dt><span class="term"><code class="option">--require-changes</code></span></dt><dd><p>
-                    Do nothing, leaving a non-existent  DIRECTORY  if nothing changes since
-                    last cached build. If this is not specified, the latest version from the cache will be put
-                    into   DIRECTORY .
-                </p></dd><dt><span class="term"><code class="option">--keep-build-dirs</code></span></dt><dd><p>
-                    Don't remove the sources and build after having built and installed each module.
-                    This also creates a symlink to the build directory with a stable name ("build-modulename").
-                </p></dd><dt><span class="term"><code class="option">--ccache</code></span></dt><dd><p>
-                     Enable use of ccache in the build (needs ccache in the sdk)
-                </p></dd><dt><span class="term"><code class="option">--stop-at=MODULENAME</code></span></dt><dd><p>
-                     Stop at the specified module, ignoring it and all the following ones
-                     in both the "download" and "build" phases. This is useful for debugging
-                     and development. For instance, you can build all the dependencies, but
-                     stop at the main application so that you can then do a build from a
-                     pre-existing checkout. Implies --build-only.
-                </p></dd><dt><span class="term"><code class="option">--repo=DIR</code></span></dt><dd><p>
-                    When build is done, run export the result to this repository.
-                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--subject=SUBJECT</code></span></dt><dd><p>
-                    One line subject for the commit message.
-                    Used when exporting the build results.
-                </p></dd><dt><span class="term"><code class="option">-b</code>, </span><span class="term"><code class="option">--body=BODY</code></span></dt><dd><p>
-                    Full description for the commit message.
-                    Used when exporting the build results.
-                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
-                    Sign the commit with this GPG key.
-                    Used when exporting the build results.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
-                    GPG Homedir to use when looking for keyrings.
-                    Used when exporting the build results.
-                </p></dd><dt><span class="term"><code class="option">--jobs=JOBS</code></span></dt><dd><p>
-                     Limit the number of parallel jobs during the build.
-                     The default is the number of CPUs on the machine.
-                </p></dd><dt><span class="term"><code class="option">--force-clean</code></span></dt><dd><p>
-                    Erase the previous contents of DIRECTORY if it is
-                    not empty.
-                </p></dd><dt><span class="term"><code class="option">--sandbox</code></span></dt><dd><p>
-                    Disable the possibility to specify build-args that
-                    are passed to flatpak build. This means the build
-                    process can't break out of its sandbox, and is
-                    useful when building less trusted software.
-                </p></dd><dt><span class="term"><code class="option">--allow-missing-runtimes</code></span></dt><dd><p>
-                    Do not immediately fail if the sdk or platform runtimes
-                    are not installed on this system. Attempting to build any
-                    manifest modules will still fail if the sdk is missing, but
-                    may be useful for apps that install files without a sandbox
-                    build.
-                </p></dd><dt><span class="term"><code class="option">--rebuild-on-sdk-change</code></span></dt><dd><p>
-                  Record the exact version of the sdk in the cache, and rebuild everything
-                  if it changes. This is useful if you're building against an API-unstable
-                  runtime, like a nightly build.
-                </p></dd><dt><span class="term"><code class="option">--skip-if-unchanged</code></span></dt><dd><p>
-                  If the json is unchanged since the last build of this filename, then
-                  do nothing, and return exit code 42.
-                </p></dd><dt><span class="term"><code class="option">--from-git=GIT</code></span></dt><dd><p>
-                  Look for the manifest in the given git repository. If this option is
-                  given, MANIFEST is interpreted as a relative path inside the repository.
-                </p></dd><dt><span class="term"><code class="option">--from-git-branch=BRANCH</code></span></dt><dd><p>
-                  The branch to use with --from-git.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821836266880"></a><h2>Caching</h2><p>
-            flatpak-builder caches sources and partial build results in
-            the .flatpak-builder subdirectory of the current directory. If you
-            use <code class="option">--keep-build-dirs</code>, build directories for each
-            module are also stored here.
-        </p><p>
-            It is safe to remove the contents of the .flatpak-builder
-            directory. This will force a full build the next time you build.
-        </p></div><div class="refsect1"><a id="idm139821836264368"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak-builder my-app-dir manifest.json</strong></span>
-        </p><p>
-            Example manifest file:
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm1951"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak document-info ~/Sources/gtk/gail-3.0.pc</strong></span>
         </p><pre class="programlisting">
-{
-    "id": "org.test.TestApp",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.2",
-    "sdk": "org.freedesktop.Sdk",
-    "command": "test",
-    "clean": [ "/include", "*.la" ],
-    "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
-        "env": {
-            "V": "1"
-        },
-        "arch": {
-            "x86_64": {
-                "cflags": "-O3 -g",
-            }
-        }
-    },
-    "modules": [
-        {
-            "name": "pygobject",
-            "config-opts": [ "--disable-introspection" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.xz",
-                    "sha256": "fb8a1d4f665130a125011659bd347c7339c944232163dbb9a34fd0686577adb8"
-                },
-                {
-                    "type": "patch",
-                    "path": "required-pygobject-fix.patch"
-                },
-                {
-                    "type": "file",
-                    "path": "pygobject-extra-file",
-                    "dest-filename": "extra-file"
-                }
-            ]
-        },
-        {
-            "name": "babl",
-            "build-options" : { "cxxflags": "-O2 -g -std=c++11" },
-            "cleanup": [ "/bin" ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "git://git.gnome.org/babl"
-                }
-            ]
-        },
-        {
-            "name": "testapp",
-            "sources": [
-                {
-                    "type": "bzr",
-                    "url": "lp:testapp"
-                }
-            ]
-        }
-    ]
-}
-</pre></div><div class="refsect1"><a id="idm139821837495616"></a><h2>See also</h2><p>
+id: dd32c34a
+path: /run/user/1000/doc/dd32c34a/gail-3.0.pc
+origin: /home/mclasen/Sources/gtk/gail-3.0.pc
+permissions:
+        org.gnome.gedit read, write
+</pre></div><div class="refsect1"><a id="idm1956"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-manifest"><span class="citerefentry"><span class="refentrytitle">flatpak-manifest</span>(5)</span></a>
-            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
-        </p></div></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="idm139821843062944"></a>Commands</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="refentrytitle"><a href="#flatpak-install">flatpak install</a></span><span class="refpurpose"> — Install an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-update">flatpak update</a></span><span class="refpurpose"> — Update an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-uninstall">flatpak uninstall</a></span><span class="refpurpose"> — Uninstall an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-list">flatpak list</a></span><span class="refpurpose"> — List installed applications and/or runtimes</span></dt><dt><span class="refentrytitle"><a href="#flatpak-info">flatpak info</a></span><span class="refpurpose"> — Show information about installed application and/or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-run">flatpak run</a></span><span class="refpurpose"> — Run an application or open a shell in a runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-override">flatpak override</a></span><span class="refpurpose"> — Override application requirements</span></dt><dt><span class="refentrytitle"><a href="#flatpak-make-current">flatpak make-current</a></span><span class="refpurpose"> — Make a specific version of an app current</span></dt><dt><span class="refentrytitle"><a href="#flatpak-enter">flatpak enter</a></span><span class="refpurpose"> — Enter an application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-export">flatpak document-export</a></span><span class="refpurpose"> — Export a file to a sandboxed application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-unexport">flatpak document-unexport</a></span><span class="refpurpose"> — Stop exporting a file</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-info">flatpak document-info</a></span><span class="refpurpose"> — Show information about exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-document-list">flatpak document-list</a></span><span class="refpurpose"> — List exported files</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remotes">flatpak remotes</a></span><span class="refpurpose"> — List remote repositories</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-add">flatpak remote-add</a></span><span class="refpurpose"> — Add a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-modify">flatpak remote-modify</a></span><span class="refpurpose"> — Modify a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-delete">flatpak remote-delete</a></span><span class="refpurpose"> — Delete a remote repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote-ls">flatpak remote-ls</a></span><span class="refpurpose"> — Show available runtimes and applications</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-init">flatpak build-init</a></span><span class="refpurpose"> — Initialize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build">flatpak build</a></span><span class="refpurpose"> — Build in a directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-finish">flatpak build-finish</a></span><span class="refpurpose"> — Finalize a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-export</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-bundle">flatpak build-bundle</a></span><span class="refpurpose"> — Create a single-file bundle from a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-import-bundle">flatpak build-import-bundle</a></span><span class="refpurpose"> — Import a file bundle into a local repository</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-export">flatpak build-sign</a></span><span class="refpurpose"> — Sign an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-update-repo">flatpak build-update-repo</a></span><span class="refpurpose"> — Create a repository from a build directory</span></dt><dt><span class="refentrytitle"><a href="#flatpak-build-commit-from">flatpak build-commit-from</a></span><span class="refpurpose"> — Create new commits based on existing one (possibly from another repository)</span></dt></dl></div><div class="refentry"><a id="flatpak-install"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-install — Install an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><p>Install from a configured remote:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...]  REMOTE-NAME   REF... </p></div><p>Install from a .flatpakref file:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...] [--from]  LOCATION </p></div><p>Install from a .flatpak bundle:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...] [--bundle]  FILENAME </p></div></div><div class="refsect1"><a id="idm139821839045360"></a><h2>Description</h2><p>
+            <a class="citerefentry" href="#flatpak-document-export"><span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-unexport"><span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-list"><span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-list"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-list — List exported files</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-list</code>  [OPTION...] [APPID]</p></div></div><div class="refsect1"><a id="idm1992"></a><h2>Description</h2><p>
+            Lists exported files, with their document id and the
+            full path to their origin. If an APPID is specified,
+            only the files exported to this app are listed.
+        </p></div><div class="refsect1"><a id="idm1995"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2018"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-export"><span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-unexport"><span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-info"><span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-unexport"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-unexport — Stop exporting a file</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-export</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm2054"></a><h2>Description</h2><p>
+            Removes the document id for the file from the
+            document portal. This will make the document unavailable
+            to all sandboxed applications.
+        </p></div><div class="refsect1"><a id="idm2057"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2080"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-export"><span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-info"><span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-document-list"><span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-enter"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-enter — Enter an application</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak enter</code>  [OPTION...]  MONITORPID   COMMAND  [ARG...]</p></div></div><div class="refsect1"><a id="idm2118"></a><h2>Description</h2><p>
+            Enter a running sandbox.
+             SANDBOXEDPID  must be the pid of a process running in a flatpak sandbox.
+              COMMAND  is the command to run in the sandbox.
+            Extra arguments are passed on to the command.
+        </p><p>
+            This creates a new process within the running sandbox, with the same environment. This is useful
+            when you want to debug a problem with a running application.
+        </p><p>
+            This command requires extra privileges, so must be run as root or via e.g. sudo.
+        </p></div><div class="refsect1"><a id="idm2125"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2148"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak enter 15345 sh</strong></span>
+        </p></div><div class="refsect1"><a id="idm2152"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-run"><span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-info"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-info — Show information about installed application and/or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak info</code>  [OPTION...]  NAME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm2183"></a><h2>Description</h2><p>
+            Show info about and installed application and/or runtime.
+        </p><p>
+            By default, the output is formatted in a friendly format.
+            If you specify one of the options --show-ref, --show-commit,
+            --show-origin, --show-metadata or --show-size, the output is instead formatted
+            in a machine-readable format.
+        </p><p>
+            By default, both per-user and system-wide installations
+            are queried. Use the --user, --system or --installation
+            options to change this.
+        </p></div><div class="refsect1"><a id="idm2188"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Query per-user installations.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Query the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Query a system-wide installation by  NAME  among
+                    those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    Query for this architecture.
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--show-ref</code></span></dt><dd><p>
+                    Show the installed ref.
+                </p></dd><dt><span class="term"><code class="option">-o</code>, </span><span class="term"><code class="option">--show-origin</code></span></dt><dd><p>
+                    Show the remote the ref is installed from.
+                </p></dd><dt><span class="term"><code class="option">-c</code>, </span><span class="term"><code class="option">--show-commit</code></span></dt><dd><p>
+                    Show the installed commit id.
+                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--show-size</code></span></dt><dd><p>
+                    Show the installed size.
+                </p></dd><dt><span class="term"><code class="option">-m</code>, </span><span class="term"><code class="option">--show-metadata</code></span></dt><dd><p>
+                    Show the metadata.
+                </p></dd><dt><span class="term"><code class="option">-e</code>, </span><span class="term"><code class="option">--show-extensions</code></span></dt><dd><p>
+                    Show the matching extensions.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2277"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak info org.gnome.Builder//master</strong></span>
+        </p></div><div class="refsect1"><a id="idm2281"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-update"><span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-install"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-install — Install an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><p>Install from a configured remote:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...]  REMOTE-NAME   REF... </p></div><p>Install from a .flatpakref file:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...] [--from]  LOCATION </p></div><p>Install from a .flatpak bundle:</p><div class="cmdsynopsis"><p><code class="command">flatpak install</code>  [OPTION...] [--bundle]  FILENAME </p></div></div><div class="refsect1"><a id="idm2328"></a><h2>Description</h2><p>
           Installs an application or runtime. The primary way to
           install is to specify a [REMOTE]
           name as the source and one ore more  [REF]s to specify the
@@ -322,7 +1035,7 @@
             against what is in the remote, and if there are multiple matches an error message
             will list the alternatives.
         </p><p>
-            By default this looks for both apps and runtime with the given  REF  in
+            By default this looks for both apps and runtimes with the given  REF  in
             the specified   REMOTE , but you can limit this by using the --app or
             --runtime option, or by supplying the initial element in the REF.
         </p><p>
@@ -340,7 +1053,7 @@
         </p><p>
             Unless overridden with the --user or the --installation option, this command installs
             the application or runtime in the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821835694256"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+        </p></div><div class="refsect1"><a id="idm2343"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
                 </p></dd><dt><span class="term"><code class="option">--bundle</code></span></dt><dd><p>
                   Assume LOCATION is a .flatpak single-bundle file.
@@ -385,7 +1098,7 @@
                     Print OSTree debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
                     Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821836229760"></a><h2>Examples</h2><p>
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2455"></a><h2>Examples</h2><p>
             <span class="command"><strong>$ flatpak install gnome org.gnome.gedit2</strong></span>
         </p><p>
             <span class="command"><strong>$ flatpak --installation=default install gnome org.gnome.gedit2</strong></span>
@@ -393,150 +1106,13 @@
             <span class="command"><strong>$ flatpak --user install gnome org.gnome.gedit//3.22</strong></span>
         </p><p>
             <span class="command"><strong>$ flatpak --user install https://sdk.gnome.org/gedit.flatpakref</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821835668944"></a><h2>See also</h2><p>
+        </p></div><div class="refsect1"><a id="idm2465"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-update"><span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-list"><span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-build-bundle"><span class="citerefentry"><span class="refentrytitle">flatpak-build-bundle</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-flatpakref"><span class="citerefentry"><span class="refentrytitle">flatpak-flatpakref</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-update"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-update — Update an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak update</code>  [OPTION...] [REF...]</p></div></div><div class="refsect1"><a id="idm139821838835424"></a><h2>Description</h2><p>
-            Updates applications and runtimes.  REF  is a reference to the
-            application or runtime to install. If no   REF  is given, everything
-            is updated.
-        </p><p>
-            Each  REF  arguments is a full or partial indentifier in the
-            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
-            except ID are optional and can be left out, including the slashes,
-            so most of the time you need only specify ID. Any part left out will be matched
-            against what is installed, and if there are multiple matches an error message
-            will list the alternatives.
-        </p><p>
-            By default this looks for both apps and runtime with the given  REF  in
-            the specified   REMOTE , but you can limit this by using the --app or
-            --runtime option, or by supplying the initial element in the REF.
-        </p><p>
-            Normally, this command updates the application to the tip
-            of its branch. But it is possible to check out another commit,
-            with the --commit option.
-        </p><p>
-            Note that updating a runtime is different from installing
-            a different branch, and runtime updates are expected to keep
-            strict compatibility. If an application update does cause
-            a problem, it is possible to go back to the previous
-            version, with the --commit option.
-        </p><p>
-            Unless overridden with the --user or the --installation option, this command updates
-            the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821836605168"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Update a per-user installation.
-                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Update the default system-wide installation.
-                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Updates a system-wide installation specified by  NAME 
-                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
-                    Using   --installation=default  is equivalent to using
-                      --system .
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    The architecture to update for.
-                </p></dd><dt><span class="term"><code class="option">--subpath=PATH</code></span></dt><dd><p>
-                  Install only a subpath of the ref. This is mainly used to install a subset of locales.
-                  This can be added multiple times to install multiple subpaths.
-                  If this is not specified the subpaths specified at install time are reused.
-                </p></dd><dt><span class="term"><code class="option">--commit=COMMIT</code></span></dt><dd><p>
-                    Update to this commit, instead of the tip of the branch.
-                </p></dd><dt><span class="term"><code class="option">--no-deploy</code></span></dt><dd><p>
-                    Download the latest version, but don't deploy it.
-                </p></dd><dt><span class="term"><code class="option">--no-pull</code></span></dt><dd><p>
-                    Don't download the latest version, deploy it whatever is locally available.
-                </p></dd><dt><span class="term"><code class="option">--no-related</code></span></dt><dd><p>
-                    Don't download related extensions, such as the locale data.
-                </p></dd><dt><span class="term"><code class="option">--no-deps</code></span></dt><dd><p>
-                    Don't update or install runtime dependencies when installing.
-                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
-                    Only look for an app with the given name.
-                </p></dd><dt><span class="term"><code class="option">--appstream</code></span></dt><dd><p>
-                    Update appstream for the remote.
-                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
-                    Only look for an runtime with the given name.
-                </p></dd><dt><span class="term"><code class="option">-y</code>, </span><span class="term"><code class="option">--assumeyes</code></span></dt><dd><p>
-                    Automatically answer yes to all questions (or pick the most prioritized answer). This is useful for automation.
-                </p></dd><dt><span class="term"><code class="option">--force-remove</code></span></dt><dd><p>
-                    Remove old files even if they're in use by a running application.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821838484464"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak --user update org.gnome.GEdit</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821836473264"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-list"><span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-uninstall"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-uninstall — Uninstall an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak uninstall</code>  [OPTION...] [REF...]</p></div></div><div class="refsect1"><a id="idm139821838648912"></a><h2>Description</h2><p>
-            Uninstalls an application or runtime.  REF  is a reference to the
-            application or runtime to install. If no   REF  is given, everything
-            is updated.
-        </p><p>
-            Each  REF  arguments is a full or partial indentifier in the
-            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
-            except ID are optional and can be left out, including the slashes,
-            so most of the time you need only specify ID. Any part left out will be matched
-            against what is installed, and if there are multiple matches an error message
-            will list the alternatives.
-        </p><p>
-            By default this looks for both installed apps and runtime
-            with the given  NAME , but you can
-            limit this by using the --app or --runtime option.
-        </p><p>
-            Normally, this command removes the ref for this application/runtime from the
-            local OSTree repository and purges and objects that are no longer
-            needed to free up disk space. If the same application is later
-            reinstalled, the objects will be pulled from the remote repository
-            again. The --keep-ref option can be used to prevent this.
-        </p><p>
-            If all branches of the application/runtime are removed, this command
-            also purges the data directory for the application.
-        </p><p>
-            Unless overridden with the --user or the --installation option, this command updates
-            the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821835740448"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--keep-ref</code></span></dt><dd><p>
-                    Keep the ref for the application and the objects belonging to it
-                    in the local repository.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Updates a per-user installation.
-                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Updates the default system-wide installation.
-                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Updates a system-wide installation specified by  NAME 
-                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
-                    Using   --installation=default  is equivalent to using
-                      --system .
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    The architecture to uninstall, instead of the architecture of
-                    the host system.
-                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
-                    Only look for an app with the given name.
-                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
-                    Only look for an runtime with the given name.
-                </p></dd><dt><span class="term"><code class="option">--no-related</code></span></dt><dd><p>
-                    Don't uninstall related extensions, such as the locale data.
-                </p></dd><dt><span class="term"><code class="option">--force-remove</code></span></dt><dd><p>
-                    Remove files even if they're in use by a running application.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821838426512"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak --user uninstall org.gnome.GEdit</strong></span>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-list"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-list — List installed applications and/or runtimes</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak list</code>  [OPTION...]</p></div></div><div class="refsect1"><a id="idm139821836528800"></a><h2>Description</h2><p>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-list"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-list — List installed applications and/or runtimes</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak list</code>  [OPTION...]</p></div></div><div class="refsect1"><a id="idm2503"></a><h2>Description</h2><p>
             Lists the names of the installed applications and/or runtime.
         </p><p>
             By default, both per-user and system-wide installations
@@ -545,7 +1121,7 @@
         </p><p>
             By default this lists both installed apps and runtime, but you can
             change this by using the --app or --runtime option.
-        </p></div><div class="refsect1"><a id="idm139821838253680"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+        </p></div><div class="refsect1"><a id="idm2508"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
                 </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
                     List per-user installations.
@@ -564,65 +1140,529 @@
                     List applications.
                 </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
                     List runtimes.
+                </p></dd><dt><span class="term"><code class="option">--all</code>, </span><span class="term"><code class="option">-a</code></span></dt><dd><p>
+                    List all installed runtimes, including locale and debug extensions. These are hidden by default.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
                     Print OSTree debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
                     Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821838498912"></a><h2>Examples</h2><p>
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2584"></a><h2>Examples</h2><p>
             <span class="command"><strong>$ flatpak --user list</strong></span>
         </p><pre class="programlisting">
 org.gnome.Builder
 org.freedesktop.glxgears
 org.gnome.MyApp
 org.gnome.GEdit
-</pre></div><div class="refsect1"><a id="idm139821839651616"></a><h2>See also</h2><p>
+</pre></div><div class="refsect1"><a id="idm2589"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-update"><span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-info"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-info — Show information about installed application and/or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak info</code>  [OPTION...]  NAME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm139821835427424"></a><h2>Description</h2><p>
-            Show info about and installed application and/or runtime.
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-make-current"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-make-current — Make a specific version of an app current</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak make-current</code>  [OPTION...]  APP   BRANCH </p></div></div><div class="refsect1"><a id="idm2623"></a><h2>Description</h2><p>
+            Makes a particular branch of an application current. Only the current branch
+            of an app has its exported files (such as desktop files and icons) made visible
+            to the host.
         </p><p>
-            By default, both per-user and system-wide installations
-            are queried. Use the --user, --system or --installation
-            options to change this.
-        </p></div><div class="refsect1"><a id="idm139821839516816"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+            When a new branch is installed it will automatically be made current, so this
+            command is often not needed.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm2628"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
                 </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Query per-user installations.
+                    Update a per-user installation.
                 </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Query the default system-wide installation.
+                    Update the default system-wide installation.
                 </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Query a system-wide installation by  NAME  among
-                    those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Updates a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
                     Using   --installation=default  is equivalent to using
                       --system .
                 </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    Query for this architecture.
-                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--show-ref</code></span></dt><dd><p>
-                    Show the installed ref.
-                </p></dd><dt><span class="term"><code class="option">-o</code>, </span><span class="term"><code class="option">--show-origin</code></span></dt><dd><p>
-                    Show the remote the ref is installed from.
-                </p></dd><dt><span class="term"><code class="option">-c</code>, </span><span class="term"><code class="option">--show-commit</code></span></dt><dd><p>
-                    Show the installed commit id.
-                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--show-size</code></span></dt><dd><p>
-                    Show the installed size.
-                </p></dd><dt><span class="term"><code class="option">-m</code>, </span><span class="term"><code class="option">--show-metadata</code></span></dt><dd><p>
-                    Show the metadata.
-                </p></dd><dt><span class="term"><code class="option">-e</code>, </span><span class="term"><code class="option">--show-extensions</code></span></dt><dd><p>
-                    Show the matching extensions.
+                    The architecture to install for.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
                     Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821836110736"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak info org.gnome.Builder//master</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821836108704"></a><h2>See also</h2><p>
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2675"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user make-current org.gnome.GEdit 3.14</strong></span>
+        </p></div><div class="refsect1"><a id="idm2679"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-update"><span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-run"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-run — Run an application or open a shell in a runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak run</code>  [OPTION...]  REF  [ARG...]</p></div></div><div class="refsect1"><a id="idm139821836967248"></a><h2>Description</h2><p>
+            <a class="citerefentry" href="#flatpak-list"><span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-override"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-override — Override application requirements</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak override</code>  [OPTION...]  APP </p></div></div><div class="refsect1"><a id="idm2712"></a><h2>Description</h2><p>
+            Overrides the application specified runtime requirements. This can be used
+            to grant a sandboxed application more or less resources than it requested.
+        </p><p>
+            By default the application gets access to the resources it
+            requested when it is started. But the user can override it
+            on a particular instance by specifying extra arguments to
+            flatpak run, or every time by using flatpak override.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm2717"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Update a per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Update the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Updates a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
+                    Share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
+                    Don't share a subsystem with the host session. This overrides
+                    the Context section from the application metadata.
+                    SUBSYSTEM must be one of: network, ipc.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
+                    Expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
+                    Don't expose a well-known socket to the application. This overrides to
+                    the Context section from the application metadata.
+                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
+                    Expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
+                    Don't expose a device to the application. This overrides to
+                    the Context section from the application metadata.
+                    DEVICE must be one of: dri, kvm, all.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
+                    Allow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                 </p><p>
+                    The <code class="code">devel</code> feature allows the application to
+                    access certain syscalls such as <code class="code">ptrace()</code>, and
+                <code class="code">perf_event_open()</code>.
+                </p><p>
+                    The <code class="code">multiarch</code> feature allows the application to
+                    execute programs compiled for an ABI other than the one supported
+                    natively by the system. For example, for the <code class="code">x86_64</code>
+                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
+                    well.
+                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
+                    Disallow access to a specific feature. This updates
+                    the [Context] group in the metadata.
+                    FEATURE must be one of: devel, multiarch.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--filesystem=FS</code></span></dt><dd><p>
+                    Allow the application access to a subset of the filesystem.
+                    This overrides to the Context section from the application metadata.
+                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
+                    xdg-config, xdg-cache, xdg-data,
+                    an absolute path, or a homedir-relative path like ~/dir or paths
+                    relative to the xdg dirs, like xdg-download/subdir.
+                    The optional :ro suffix indicates that the location will be read-only.
+                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
+                    Remove access to the specified subset of the filesystem from
+                    the application. This overrides to the Context section from the
+                    application metadata.
+                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
+                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
+                    an absolute path, or a homedir-relative path like ~/dir.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
+</p><pre class="programlisting">
+[Policy subsystem]
+key=v1;v2;
+</pre><p>
+                </p><p>
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
+                    Remove generic policy option. This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
+                    Set an environment variable in the application.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well-known name NAME on the session bus.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
+                    Allow the application to own the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to own all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
+                    Allow the application to talk to the well known name NAME on the system bus.
+                    If NAME ends with .*, it allows the application to talk to all matching names.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
+                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
+                    FILENAME a bind mount to the corresponding path in the per-application directory,
+                    allowing that location to be used for persistent data.
+                    This overrides to the Context section from the application metadata.
+                    This option can be used multiple times.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm2860"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak override --nosocket=wayland org.gnome.GEdit</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak override --filesystem=home org.mozilla.Firefox</strong></span>
+        </p></div><div class="refsect1"><a id="idm2866"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-run"><span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-add"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-add — Add a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><p>Add from a .flatpakrepo file:</p><div class="cmdsynopsis"><p><code class="command">flatpak remote-add</code>  [OPTION...] [--from]  NAME   LOCATION </p></div><p>Manually specify repo uri and options:</p><div class="cmdsynopsis"><p><code class="command">flatpak remote-add</code>  [OPTION...]  NAME   LOCATION </p></div></div><div class="refsect1"><a id="idm2905"></a><h2>Description</h2><p>
+            Adds a remote repository to the flatpak repository
+            configuration.  [NAME] is the name for the new
+            remote, and  [LOCATION] is a url or pathname.  The
+             [LOCATION] is either a flatpak repository, or a
+            .flatpakrepo file which describes a repository. In the
+            former case you may also have to specify extra options,
+            such as the gpg key for the repo.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm2912"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--from</code></span></dt><dd><p>
+                  Assume the URI is a .flatpakrepo file rather than the repository itself. This is enabled
+                  by default if the extension is .flatpakrepo, so generally you don't need this option.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Modify the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Modify the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Modify a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--no-gpg-verify</code></span></dt><dd><p>
+                    Disable GPG verification for the added remote.
+                </p></dd><dt><span class="term"><code class="option">--prio=PRIO</code></span></dt><dd><p>
+                    Set the priority for the remote. Default is 1, higher is more prioritized. This is
+                    mainly used for graphical installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-enumerate</code></span></dt><dd><p>
+                    Mark the remote as not enumerated. This means the remote will
+                    not be used to list applications, for instance in graphical
+                    installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-use-for-deps</code></span></dt><dd><p>
+                    Mark the remote as not to be used for automatic runtime
+                    dependency resolution.
+                </p></dd><dt><span class="term"><code class="option">--if-not-exists</code></span></dt><dd><p>
+                    Do nothing if the provided remote already exists.
+                </p></dd><dt><span class="term"><code class="option">--disable</code></span></dt><dd><p>
+                    Disable the added remote.
+                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
+                    A title for the remote, e.g. for display in a UI.
+                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
+                    A default branch for the remote, mainly for use in a UI.
+                </p></dd><dt><span class="term"><code class="option">--gpg-import=FILE</code></span></dt><dd><p>
+                     Import gpg keys from the specified keyring file as
+                     trusted for the new remote. If the file is - the
+                     keyring is read from standard input.
+                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
+                    This is a OCI format registry rather than a regular
+                    flatpak repository.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3014"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak remote-add gnome https://sdk.gnome.org/gnome.flatpakrepo</strong></span>
+        </p><p>
+            <span class="command"><strong>$ flatpak --user remote-add --no-gpg-verify test-repo https://people.gnome.org/~alexl/gnome-sdk/repo/</strong></span>
+        </p></div><div class="refsect1"><a id="idm3020"></a><h2>See also</h2><p>
+                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-modify"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-modify</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-delete"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-delete</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-flatpakrepo"><span class="citerefentry"><span class="refentrytitle">flatpak-flatpakrepo</span>(1)</span></a>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-delete"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-delete — Delete a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-delete</code>  [OPTION...]  NAME </p></div></div><div class="refsect1"><a id="idm3059"></a><h2>Description</h2><p>
+            Removes a remote repository from the flatpak repository configuration.
+             NAME  is the name of an existing remote.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm3064"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Modify the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Modify the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Modify a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--force</code></span></dt><dd><p>
+                    Remove remote even if its in use by installed apps or runtimes.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3116"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user remote-delete dried-raisins</strong></span>
+        </p></div><div class="refsect1"><a id="idm3120"></a><h2>See also</h2><p>
+                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-add"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-modify"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-modify</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span></a>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-info"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-info — Show information about an application or runtime in a remote</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-info</code>  [OPTION...]  REMOTE   REF </p></div></div><div class="refsect1"><a id="idm3157"></a><h2>Description</h2><p>
+            Shows information about the runtime or application  REF  from the
+            remote repository with the name   REMOTE .
+            You can find all configured remote repositories with flatpak remotes.
+        </p><p>
+            By default, the output is formatted in a friendly format.
+            If you specify one of the options --show-ref, --show-commit,
+            --show-parent, or --show-metadata, the output is instead formatted
+            in a machine-readable format.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            uses the default system-wide configuration.
+        </p></div><div class="refsect1"><a id="idm3164"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Use the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Use the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Use a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Assume that  REF  is a runtime if not explicitly specified.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Assume that  REF  is an app if not explicitly specified.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The default architecture to look for, if not given explicitly in the  REF .
+                </p></dd><dt><span class="term"><code class="option">--commit=COMMIT</code></span></dt><dd><p>
+                    Show information about the specific commit, rather than the latest version.
+                </p></dd><dt><span class="term"><code class="option">--log</code></span></dt><dd><p>
+                    Display a log of previous versions.
+                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--show-ref</code></span></dt><dd><p>
+                    Show the matched ref.
+                </p></dd><dt><span class="term"><code class="option">-c</code>, </span><span class="term"><code class="option">--show-commit</code></span></dt><dd><p>
+                    Show the commit id.
+                </p></dd><dt><span class="term"><code class="option">-p</code>, </span><span class="term"><code class="option">--show-parent</code></span></dt><dd><p>
+                    Show the parent commit id.
+                </p></dd><dt><span class="term"><code class="option">-m</code>, </span><span class="term"><code class="option">--show-metadata</code></span></dt><dd><p>
+                    Show the metadata.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3262"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user remote-info flathub org.gnome.gedit</strong></span>
+        </p><pre class="programlisting">
+Ref: app/org.gnome.gedit/x86_64/stable
+ID: org.gnome.gedit
+Arch: x86_64
+Branch: stable
+Date: 2017-07-31 16:05:22 +0000
+Subject: Build org.gnome.gedit at 3ec291fc1ce4d78220527fa79576f4cc1481ebe5
+Commit: 3de7e9dde3bb8382aad9dfbbff20eccd9bf2100bc1887a3619ec0372e8066bf7
+Parent: -
+Download size: 3,4 MB
+Installed size: 11,1 MB
+Runtime: org.gnome.Platform/x86_64/3.24
+</pre></div><div class="refsect1"><a id="idm3267"></a><h2>See also</h2><p>
+                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span></a>
+                <a class="citerefentry" href="#flatpak-remote-ls"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-ls</span>(1)</span></a>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-ls"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-ls — Show available runtimes and applications</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-ls</code>  [OPTION...] [REMOTE]</p></div></div><div class="refsect1"><a id="idm3300"></a><h2>Description</h2><p>
+            Shows runtimes and applications that are available in the
+            remote repository with the name  REMOTE ,
+            or all remotes if one isn't specified. You can find all configured
+            remote repositories with <a class="citerefentry" href="#flatpak-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span></a>.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            uses the default system-wide configuration.
+        </p></div><div class="refsect1"><a id="idm3308"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Use the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Use the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Use a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--show-details</code></span></dt><dd><p>
+                    Show arches, branches and commit ids, in addition to the names.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Show only runtimes, omit applications.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Show only applications, omit runtimes.
+                </p></dd><dt><span class="term"><code class="option">--all</code>, </span><span class="term"><code class="option">-a</code></span></dt><dd><p> Show everything. By default locale and
+                debug extensions as well as secondary arches when the primary
+                arch in available are hidden.
+                </p></dd><dt><span class="term"><code class="option">--updates</code></span></dt><dd><p>
+                    Show only those which have updates available.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    Show only those matching the specied architecture. By default, only
+                    supported architectures are shown. Use --arch=* to show all archtectures.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3389"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user remote-ls --app testrepo</strong></span>
+        </p><pre class="programlisting">
+org.gnome.Builder
+org.freedesktop.glxgears
+</pre></div><div class="refsect1"><a id="idm3394"></a><h2>See also</h2><p>
+                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span></a>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-modify"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-modify — Modify a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-modify</code>  [OPTION...]  NAME </p></div></div><div class="refsect1"><a id="idm3424"></a><h2>Description</h2><p>
+            Modifies options for an existing remote repository in the flatpak repository configuration.
+             NAME  is the name for the remote.
+        </p><p>
+            Unless overridden with the --user or --installation options, this command
+            changes the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm3429"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Modify the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Modify the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Modify a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">--no-gpg-verify</code></span></dt><dd><p>
+                    Disable GPG verification for the added remote.
+                </p></dd><dt><span class="term"><code class="option">--gpg-verify</code></span></dt><dd><p>
+                    Enable GPG verification for the added remote.
+                </p></dd><dt><span class="term"><code class="option">--prio=PRIO</code></span></dt><dd><p>
+                    Set the priority for the remote. Default is 1, higher is more prioritized. This is
+                    mainly used for graphical installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-enumerate</code></span></dt><dd><p>
+                    Mark the remote as not enumerated. This means the remote will
+                    not be used to list applications, for instance in graphical
+                    installation tools.
+                </p></dd><dt><span class="term"><code class="option">--no-use-for-deps</code></span></dt><dd><p>
+                    Mark the remote as not to be used for automatic runtime
+                    dependency resolution.
+                </p></dd><dt><span class="term"><code class="option">--disable</code></span></dt><dd><p>
+                    Disable the remote. Disabled remotes will not be automatically updated from.
+                </p></dd><dt><span class="term"><code class="option">--enable</code></span></dt><dd><p>
+                    Enable the remote.
+                </p></dd><dt><span class="term"><code class="option">--enumerate</code></span></dt><dd><p>
+                    Mark the remote as enumerated. This means the remote will
+                    be used to list applications, for instance in graphical
+                    installation tools.
+                </p></dd><dt><span class="term"><code class="option">--use-for-deps</code></span></dt><dd><p>
+                    Mark the remote as to be used for automatic runtime
+                    dependency resolution.
+                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
+                    A title for the remote, e.g. for display in a UI.
+                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
+                    A default branch to for the remote, mainly for use in a UI.
+                </p></dd><dt><span class="term"><code class="option">--url=URL</code></span></dt><dd><p>
+                    Set a new URL.
+                </p></dd><dt><span class="term"><code class="option">--update-metadata</code></span></dt><dd><p>
+                    A default branch to for the remote, mainly for use in a UI.
+                </p><p>
+                    Update the remote's extra metadata from the OSTree repository's summary
+                    file. Only xa.title and xa.default-branch are supported at the moment.
+                </p></dd><dt><span class="term"><code class="option">--gpg-import=FILE</code></span></dt><dd><p>
+                     Import gpg keys from the specified keyring file as
+                     trusted for the new remote. If the file is - the
+                     keyring is read from standard input.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3548"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user remote-modify --no-gpg-verify test-repo</strong></span>
+        </p></div><div class="refsect1"><a id="idm3552"></a><h2>See also</h2><p>
+                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-add"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-delete"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-delete</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span></a>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remotes"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remotes — List remote repositories</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remotes</code>  [OPTION...]</p></div></div><div class="refsect1"><a id="idm3587"></a><h2>Description</h2><p>
+            Lists the known remote repositories, in priority order.
+        </p><p>
+            By default, both per-user and system-wide installations
+            are shown. Use the --user, --system or --installation
+            options to change this.
+        </p></div><div class="refsect1"><a id="idm3591"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Show the per-user configuration.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Show the default system-wide configuration.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Show a system-wide installation by  NAME  among
+                    those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
+                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--show-details</code></span></dt><dd><p>
+                    Show more information for each repository in addition to the name.
+                </p></dd><dt><span class="term"><code class="option">--show-disabled</code></span></dt><dd><p>
+                    Show disabled repos.
+                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
+                    Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
+                    Print version information and exit.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3650"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak remotes --user --show-details</strong></span>
+        </p><pre class="programlisting">
+testrepo	Test Repository	 http://209.132.179.91/repo/ no-gpg-verify
+</pre></div><div class="refsect1"><a id="idm3655"></a><h2>See also</h2><p>
+                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-add"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span></a>,
+                <a class="citerefentry" href="#flatpak-remote-delete"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-delete</span>(1)</span></a>
+            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-repo"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-repo — Show information about a local repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak repo</code>  [OPTION...]  LOCATION </p></div></div><div class="refsect1"><a id="idm3688"></a><h2>Description</h2><p>
+            Show information about a local repository.
+        </p></div><div class="refsect1"><a id="idm3691"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--info</code></span></dt><dd><p>
+                    Print general information about a local repository.
+                </p></dd><dt><span class="term"><code class="option">--branches</code></span></dt><dd><p>
+                    List the branches in a local repository.
+                </p></dd><dt><span class="term"><code class="option">--metadata=BRANCH</code></span></dt><dd><p>
+                  Print metadata for a branch in the repository.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3717"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak repo --info ~/my-repo</strong></span>
+        </p></div><div class="refsect1"><a id="idm3721"></a><h2>See also</h2><p>
+            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-info"><span class="citerefentry"><span class="refentrytitle">flatpak-info</span>(1)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-run"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-run — Run an application or open a shell in a runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak run</code>  [OPTION...]  REF  [ARG...]</p></div></div><div class="refsect1"><a id="idm3752"></a><h2>Description</h2><p>
             If  REF  names an installed application,
             flatpak runs the application in a sandboxed environment. Extra
             arguments are passed on to the application.
@@ -639,7 +1679,10 @@ org.gnome.GEdit
             metadata and various options like --share and --socket that are passed to the run
             command: Access is allowed if it was requested either in the application
             metadata file or with an option and the user hasn't overridden it.
-        </p></div><div class="refsect1"><a id="idm139821838763968"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+        </p><p>
+            The remaining arguments are passed to the command that gets run in the sandboxed
+            environment. See the <code class="option">--file-forwarding</code> for handling of file arguments.
+        </p></div><div class="refsect1"><a id="idm3765"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
@@ -766,1239 +1809,256 @@ key=v1;v2;
                 </p></dd><dt><span class="term"><code class="option">--log-system-bus</code></span></dt><dd><p>
                     Log system bus traffic. This can be useful to see what access you need to allow in
                     your D-Bus policy.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821835227264"></a><h2>Examples</h2><p>
+                </p></dd><dt><span class="term"><code class="option">--file-forwarding</code></span></dt><dd><p>
+                    If this option is specified, the remaining arguments are scanned, and all arguments
+                    that are enclosed between a pair of '@@' arguments are interpreted as file paths,
+                    exported in the document store, and passed to the command in the form of the
+                    resulting document path. Arguments between '@@u' and '@@' are considered uris,
+                    and any file: uris are exported. The exports are non-persistent and with read and write
+                    permissions for the application.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm3929"></a><h2>Examples</h2><p>
             <span class="command"><strong>$ flatpak run org.gnome.GEdit</strong></span>
         </p><p>
             <span class="command"><strong>$ flatpak run --devel --command=bash org.gnome.Builder</strong></span>
         </p><p>
             <span class="command"><strong>$ flatpak run --command=bash org.gnome.Sdk</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821835222912"></a><h2>See also</h2><p>
+        </p></div><div class="refsect1"><a id="idm3937"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-override"><span class="citerefentry"><span class="refentrytitle">flatpak-override</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-enter"><span class="citerefentry"><span class="refentrytitle">flatpak-enter</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-override"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-override — Override application requirements</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak override</code>  [OPTION...]  APP </p></div></div><div class="refsect1"><a id="idm139821835641328"></a><h2>Description</h2><p>
-            Overrides the application specified runtime requirements. This can be used
-            to grant a sandboxed application more or less resources than it requested.
-        </p><p>
-            By default the application gets access to the resources it
-            requested when it is started. But the user can override it
-            on a particular instance by specifying extra arguments to
-            flatpak run, or every time by using flatpak override.
-        </p><p>
-            Unless overridden with the --user or --installation options, this command
-            changes the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821836172480"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Update a per-user installation.
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-search"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-search — Search for applications and runtimes</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak search</code>   TEXT </p></div></div><div class="refsect1"><a id="idm3969"></a><h2>Description</h2><p>
+            Searches for applications and runtimes matching
+             TEXT . Note that this uses appstream data
+            that can be updated with <a class="citerefentry" href="#flatpak-update"><span class="citerefentry"><span class="refentrytitle">flatpak-update</span>(1)</span></a>.
+        </p></div><div class="refsect1"><a id="idm3976"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Only search through remotes in the per-user installation.
                 </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Update the default system-wide installation.
-                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Updates a system-wide installation specified by  NAME 
-                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
-                    Using   --installation=default  is equivalent to using
-                      --system .
-                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
-                    Share a subsystem with the host session. This overrides
-                    the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
-                    Don't share a subsystem with the host session. This overrides
-                    the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
-                    Expose a well-known socket to the application. This overrides to
-                    the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
-                    Don't expose a well-known socket to the application. This overrides to
-                    the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
-                    Expose a device to the application. This overrides to
-                    the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
-                    Don't expose a device to the application. This overrides to
-                    the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
-                    Allow access to a specific feature. This updates
-                    the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
-                    This option can be used multiple times.
-                 </p><p>
-                    The <code class="code">devel</code> feature allows the application to
-                    access certain syscalls such as <code class="code">ptrace()</code>, and
-                <code class="code">perf_event_open()</code>.
-                </p><p>
-                    The <code class="code">multiarch</code> feature allows the application to
-                    execute programs compiled for an ABI other than the one supported
-                    natively by the system. For example, for the <code class="code">x86_64</code>
-                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
-                    well.
-                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
-                    Disallow access to a specific feature. This updates
-                    the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--filesystem=FS</code></span></dt><dd><p>
-                    Allow the application access to a subset of the filesystem.
-                    This overrides to the Context section from the application metadata.
-                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
-                    xdg-config, xdg-cache, xdg-data,
-                    an absolute path, or a homedir-relative path like ~/dir or paths
-                    relative to the xdg dirs, like xdg-download/subdir.
-                    The optional :ro suffix indicates that the location will be read-only.
-                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
-                    application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
-                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
-</p><pre class="programlisting">
-[Policy subsystem]
-key=v1;v2;
-</pre><p>
-                </p><p>
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
-                    Remove generic policy option. This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
-                    Set an environment variable in the application.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
-                    Allow the application to own the well-known name NAME on the session bus.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
-                    Allow the application to talk to the well-known name NAME on the session bus.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
-                    Allow the application to own the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
-                    Allow the application to talk to the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
-                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
-                    FILENAME a bind mount to the corresponding path in the per-application directory,
-                    allowing that location to be used for persistent data.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821835086208"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak override --nosocket=wayland org.gnome.GEdit</strong></span>
-        </p><p>
-            <span class="command"><strong>$ flatpak override --filesystem=home org.mozilla.Firefox</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821835083040"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-run"><span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-make-current"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-make-current — Make a specific version of an app current</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak make-current</code>  [OPTION...]  APP   BRANCH </p></div></div><div class="refsect1"><a id="idm139821838344416"></a><h2>Description</h2><p>
-            Makes a particular branch of an application current. Only the current branch
-            of an app has its exported files (such as desktop files and icons) made visible
-            to the host.
-        </p><p>
-            When a new branch is installed it will automatically be made current, so this
-            command is often not needed.
-        </p><p>
-            Unless overridden with the --user or --installation options, this command
-            changes the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821836589248"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Update a per-user installation.
-                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Update the default system-wide installation.
-                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Updates a system-wide installation specified by  NAME 
-                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
-                    Using   --installation=default  is equivalent to using
-                      --system .
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    The architecture to install for.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821838389088"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak --user make-current org.gnome.GEdit 3.14</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821838998784"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-list"><span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-enter"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-enter — Enter an application</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak enter</code>  [OPTION...]  MONITORPID   COMMAND  [ARG...]</p></div></div><div class="refsect1"><a id="idm139821839264768"></a><h2>Description</h2><p>
-            Enter a running sandbox.
-             SANDBOXEDPID  must be the pid of a process running in a flatpak sandbox.
-              COMMAND  is the command to run in the sandbox.
-            Extra arguments are passed on to the command.
-        </p><p>
-            This creates a new process within the running sandbox, with the same environment. This is useful
-            when you want to debug a problem with a running application.
-        </p><p>
-            This command requires extra privileges, so must be run as root or via e.g. sudo.
-        </p></div><div class="refsect1"><a id="idm139821834927120"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834846432"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak enter 15345 sh</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821838198208"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-run"><span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-export — Export a file to a sandboxed application</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-export</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm139821839023296"></a><h2>Description</h2><p>
-            Creates a document id for a local file that can be exposed to
-            sandboxed applications, allowing them access to files that they
-            would not otherwise see. The exported files are exposed in a
-            fuse filesystem at /run/user/$UID/doc/.
-        </p><p>
-            This command also lets you modify the per-application
-            permissions of the documents, granting or revoking access
-            to the file on a per-application basis.
-        </p></div><div class="refsect1"><a id="idm139821839177824"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">-u</code>, </span><span class="term"><code class="option">--unique</code></span></dt><dd><p> Don't reuse an existing document id
-                for the file.  This makes it safe to later remove the
-                document when you're finished with it.
-                </p></dd><dt><span class="term"><code class="option">-t</code>, </span><span class="term"><code class="option">--transient</code></span></dt><dd><p>
-                  The document will only exist for the length of
-                  the session. This is useful for temporary grants.
-                </p></dd><dt><span class="term"><code class="option">-n</code>, </span><span class="term"><code class="option">--noexist</code></span></dt><dd><p>
-                  Don't require the file to exist already.
-                </p></dd><dt><span class="term"><code class="option">-a</code>, </span><span class="term"><code class="option">--app=APPID</code></span></dt><dd><p>
-                  Grant read access to the specified application. The
-                  --allow and --forbid options can be used to grant
-                  or remove additional privileges.
-                  This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--allow-read</code></span></dt><dd><p>
-                  Grant read access to the applications specified with --app.
-                  This defaults to TRUE.
-                </p></dd><dt><span class="term"><code class="option">--forbid-read</code></span></dt><dd><p>
-                  Revoke read access for the applications specified with --app.
-                </p></dd><dt><span class="term"><code class="option">-w</code>, </span><span class="term"><code class="option">--allow-write</code></span></dt><dd><p>
-                  Grant write access to the applications specified with --app.
-                </p></dd><dt><span class="term"><code class="option">--forbid-write</code></span></dt><dd><p>
-                  Revoke write access for the applications specified with --app.
-                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--allow-delete</code></span></dt><dd><p>
-                  Grant the ability to remove the document from the document portal to the applications specified with --app.
-                </p></dd><dt><span class="term"><code class="option">--forbid-delete</code></span></dt><dd><p>
-                  Revoke the ability to remove the document from the document portal from the applications specified with --app.
-                </p></dd><dt><span class="term"><code class="option">-g</code>, </span><span class="term"><code class="option">--allow-grant-permission</code></span></dt><dd><p>
-                  Grant the ability to grant further permissions to the applications specified with --app.
-                </p></dd><dt><span class="term"><code class="option">--forbid-grant-permission</code></span></dt><dd><p>
-                  Revoke the ability to grant further permissions for the applications specified with --app.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834992464"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak document-export --app=org.gnome.GEdit ~/test.txt</strong></span>
-        </p><pre class="programlisting">
-/run/user/1000/doc/e52f9c6a/test.txt
-</pre></div><div class="refsect1"><a id="idm139821834989696"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-unexport"><span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-info"><span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-list"><span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-unexport"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-unexport — Stop exporting a file</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-export</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm139821837774928"></a><h2>Description</h2><p>
-            Removes the document id for the file from the
-            document portal. This will make the document unavailable
-            to all sandboxed applications.
-        </p></div><div class="refsect1"><a id="idm139821837607200"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834863888"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-export"><span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-info"><span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-list"><span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-info"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-info — Show information about exported files</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-info</code>  [OPTION...]  FILE </p></div></div><div class="refsect1"><a id="idm139821837726912"></a><h2>Description</h2><p>
-            Shows information about an exported file, such as the
-            document id, the fuse path, the original location in the
-            filesystem, and the per-application permissions.
-        </p><p>
-            FILE can either be a file in the fuse filesystem at /run/user/$UID/doc/,
-            or a file anywhere else.
-        </p></div><div class="refsect1"><a id="idm139821836251984"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821836275360"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak document-info ~/Sources/gtk/gail-3.0.pc</strong></span>
-        </p><pre class="programlisting">
-id: dd32c34a
-path: /run/user/1000/doc/dd32c34a/gail-3.0.pc
-origin: /home/mclasen/Sources/gtk/gail-3.0.pc
-permissions:
-        org.gnome.gedit read, write
-</pre></div><div class="refsect1"><a id="idm139821839443776"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-export"><span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-unexport"><span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-list"><span class="citerefentry"><span class="refentrytitle">flatpak-document-list</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-document-list"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-document-list — List exported files</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak document-list</code>  [OPTION...] [APPID]</p></div></div><div class="refsect1"><a id="idm139821835870000"></a><h2>Description</h2><p>
-            Lists exported files, with their document id and the
-            full path to their origin. If an APPID is specified,
-            only the files exported to this app are listed.
-        </p></div><div class="refsect1"><a id="idm139821838307072"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821837824384"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-export"><span class="citerefentry"><span class="refentrytitle">flatpak-document-export</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-unexport"><span class="citerefentry"><span class="refentrytitle">flatpak-document-unexport</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-document-info"><span class="citerefentry"><span class="refentrytitle">flatpak-document-info</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remotes"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remotes — List remote repositories</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remotes</code>  [OPTION...]</p></div></div><div class="refsect1"><a id="idm139821838164960"></a><h2>Description</h2><p>
-            Lists the known remote repositories, in priority order.
-        </p><p>
-            By default, both per-user and system-wide installations
-            are shown. Use the --user, --system or --installation
-            options to change this.
-        </p></div><div class="refsect1"><a id="idm139821836987744"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Show the per-user configuration.
-                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Show the default system-wide configuration.
+                    Only search through remotes in the default system-wide installation.
                 </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
                     Show a system-wide installation by  NAME  among
                     those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
                     Using   --installation=default  is equivalent to using
                       --system .
-                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--show-details</code></span></dt><dd><p>
-                    Show more information each repository in addition to the name.
-                </p></dd><dt><span class="term"><code class="option">--show-disabled</code></span></dt><dd><p>
-                    Show disabled repos.
+                </p></dd><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+                    Show help options and exit.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821838904416"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak remotes --user --show-details</strong></span>
-        </p><pre class="programlisting">
-testrepo	Test Repository	 http://209.132.179.91/repo/ no-gpg-verify
-</pre></div><div class="refsect1"><a id="idm139821838901760"></a><h2>See also</h2><p>
-                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-add-remote"><span class="citerefentry"><span class="refentrytitle">flatpak-add-remote</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-delete-remote"><span class="citerefentry"><span class="refentrytitle">flatpak-delete-remote</span>(1)</span></a>
-            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-add"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-add — Add a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><p>Add from a .flatpakrepo file:</p><div class="cmdsynopsis"><p><code class="command">flatpak remote-add</code>  [OPTION...] [--from]  NAME   LOCATION </p></div><p>Manually specify repo uri and options:</p><div class="cmdsynopsis"><p><code class="command">flatpak remote-add</code>  [OPTION...]  NAME   LOCATION </p></div></div><div class="refsect1"><a id="idm139821836103696"></a><h2>Description</h2><p>
-            Adds a remote repository to the flatpak repository
-            configuration.  [NAME] is the name for the new
-            remote, and  [LOCATION] is a url or pathname.  The
-             [LOCATION] is either a flatpak repository, or a
-            .flatpakrepo file which describes a repository. In the
-            former case you may also have to specify extra options,
-            such as the gpg key for the repo.
+                </p></dd></dl></div></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-uninstall"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-uninstall — Uninstall an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak uninstall</code>  [OPTION...] [REF...]</p></div></div><div class="refsect1"><a id="idm4034"></a><h2>Description</h2><p>
+            Uninstalls an application or runtime.  REF  is a reference to the
+            application or runtime to uninstall.
         </p><p>
-            Unless overridden with the --user or --installation options, this command
-            changes the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821836098560"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+            Each  REF  arguments is a full or partial indentifier in the
+            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
+            except ID are optional and can be left out, including the slashes,
+            so most of the time you need only specify ID. Any part left out will be matched
+            against what is installed, and if there are multiple matches an error message
+            will list the alternatives.
+        </p><p>
+            By default this looks for both installed apps and runtime
+            with the given  NAME , but you can
+            limit this by using the --app or --runtime option.
+        </p><p>
+            Normally, this command removes the ref for this application/runtime from the
+            local OSTree repository and purges and objects that are no longer
+            needed to free up disk space. If the same application is later
+            reinstalled, the objects will be pulled from the remote repository
+            again. The --keep-ref option can be used to prevent this.
+        </p><p>
+            If all branches of the application/runtime are removed, this command
+            also purges the data directory for the application.
+        </p><p>
+            Unless overridden with the --user or the --installation option, this command updates
+            the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm4045"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--from</code></span></dt><dd><p>
-                  Assume the URI is a .flatpakrepo file rather than the repository itself. This is enabled
-                  by default if the extension is .flatpakrepo, so generally you don't need this option.
+                </p></dd><dt><span class="term"><code class="option">--keep-ref</code></span></dt><dd><p>
+                    Keep the ref for the application and the objects belonging to it
+                    in the local repository.
                 </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Modify the per-user configuration.
+                    Updates a per-user installation.
                 </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Modify the default system-wide configuration.
+                    Updates the default system-wide installation.
                 </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Modify a system-wide installation specified by  NAME 
+                    Updates a system-wide installation specified by  NAME 
                     among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
                     Using   --installation=default  is equivalent to using
                       --system .
-                </p></dd><dt><span class="term"><code class="option">--no-gpg-verify</code></span></dt><dd><p>
-                    Disable GPG verification for the added remote.
-                </p></dd><dt><span class="term"><code class="option">--prio=PRIO</code></span></dt><dd><p>
-                    Set the priority for the remote. Default is 1, higher is more prioritized. This is
-                    mainly used for graphical installation tools.
-                </p></dd><dt><span class="term"><code class="option">--no-enumerate</code></span></dt><dd><p>
-                    Mark the remote as not enumerated. This means the remote will
-                    not be used to list applications, for instance in graphical
-                    installation tools.
-                </p></dd><dt><span class="term"><code class="option">--no-use-for-deps</code></span></dt><dd><p>
-                    Mark the remote as not to be used for automatic runtime
-                    dependency resolution.
-                </p></dd><dt><span class="term"><code class="option">--if-not-exists</code></span></dt><dd><p>
-                    Do nothing if the provided remote already exists.
-                </p></dd><dt><span class="term"><code class="option">--disable</code></span></dt><dd><p>
-                    Disable the added remote.
-                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
-                    A title for the remote, e.g. for display in a UI.
-                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
-                    A default branch for the remote, mainly for use in a UI.
-                </p></dd><dt><span class="term"><code class="option">--gpg-import=FILE</code></span></dt><dd><p>
-                     Import gpg keys from the specified keyring file as
-                     trusted for the new remote. If the file is - the
-                     keyring is read from standard input.
-                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
-                    This is a OCI format registry rather than a regular
-                    flatpak repository.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834614880"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak remote-add gnome https://sdk.gnome.org/gnome.flatpakrepo</strong></span>
-        </p><p>
-            <span class="command"><strong>$ flatpak --user remote-add --no-gpg-verify test-repo https://people.gnome.org/~alexl/gnome-sdk/repo/</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821834611600"></a><h2>See also</h2><p>
-                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-modify-remote"><span class="citerefentry"><span class="refentrytitle">flatpak-modify-remote</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-delete-remote"><span class="citerefentry"><span class="refentrytitle">flatpak-delete-remote</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-list-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-list-remotes</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-flatpakrepo"><span class="citerefentry"><span class="refentrytitle">flatpak-flatpakrepo</span>(1)</span></a>
-            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-modify"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-modify — Modify a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-modify</code>  [OPTION...]  NAME </p></div></div><div class="refsect1"><a id="idm139821835925280"></a><h2>Description</h2><p>
-            Modifies options for an existing remote repository in the flatpak repository configuration.
-             NAME  is the name for the remote.
-        </p><p>
-            Unless overridden with the --user or --installation options, this command
-            changes the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821837233776"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Modify the per-user configuration.
-                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Modify the default system-wide configuration.
-                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Modify a system-wide installation specified by  NAME 
-                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
-                    Using   --installation=default  is equivalent to using
-                      --system .
-                </p></dd><dt><span class="term"><code class="option">--no-gpg-verify</code></span></dt><dd><p>
-                    Disable GPG verification for the added remote.
-                </p></dd><dt><span class="term"><code class="option">--gpg-verify</code></span></dt><dd><p>
-                    Enable GPG verification for the added remote.
-                </p></dd><dt><span class="term"><code class="option">--prio=PRIO</code></span></dt><dd><p>
-                    Set the priority for the remote. Default is 1, higher is more prioritized. This is
-                    mainly used for graphical installation tools.
-                </p></dd><dt><span class="term"><code class="option">--no-enumerate</code></span></dt><dd><p>
-                    Mark the remote as not enumerated. This means the remote will
-                    not be used to list applications, for instance in graphical
-                    installation tools.
-                </p></dd><dt><span class="term"><code class="option">--no-use-for-deps</code></span></dt><dd><p>
-                    Mark the remote as not to be used for automatic runtime
-                    dependency resolution.
-                </p></dd><dt><span class="term"><code class="option">--disable</code></span></dt><dd><p>
-                    Disable the remote. Disabled remotes will not be automatically updated from.
-                </p></dd><dt><span class="term"><code class="option">--enable</code></span></dt><dd><p>
-                    Enable the remote.
-                </p></dd><dt><span class="term"><code class="option">--enumerate</code></span></dt><dd><p>
-                    Mark the remote as enumerated. This means the remote will
-                    be used to list applications, for instance in graphical
-                    installation tools.
-                </p></dd><dt><span class="term"><code class="option">--use-for-deps</code></span></dt><dd><p>
-                    Mark the remote as to be used for automatic runtime
-                    dependency resolution.
-                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
-                    A title for the remote, e.g. for display in a UI.
-                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
-                    A default branch to for the remote, mainly for use in a UI.
-                </p></dd><dt><span class="term"><code class="option">--url=URL</code></span></dt><dd><p>
-                    Set a new URL.
-                </p></dd><dt><span class="term"><code class="option">--update-metadata</code></span></dt><dd><p>
-                    A default branch to for the remote, mainly for use in a UI.
-                </p><p>
-                    Update the remote's extra metadata from the OSTree repository's summary
-                    file. Only xa.title and xa.default-branch are supported at the moment.
-                </p></dd><dt><span class="term"><code class="option">--gpg-import=FILE</code></span></dt><dd><p>
-                     Import gpg keys from the specified keyring file as
-                     trusted for the new remote. If the file is - the
-                     keyring is read from standard input.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821835127520"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak --user remote-modify --no-gpg-verify test-repo</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821835125488"></a><h2>See also</h2><p>
-                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-remote-add"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-remote-delete"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-delete</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-remotes</span>(1)</span></a>
-            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-delete"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-delete — Delete a remote repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-delete</code>  [OPTION...]  NAME </p></div></div><div class="refsect1"><a id="idm139821838653424"></a><h2>Description</h2><p>
-            Removes a remote repository from the flatpak repository configuration.
-             NAME  is the name of an existing remote.
-        </p><p>
-            Unless overridden with the --user or --installation options, this command
-            changes the default system-wide installation.
-        </p></div><div class="refsect1"><a id="idm139821836447968"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Modify the per-user configuration.
-                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Modify the default system-wide configuration.
-                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Modify a system-wide installation specified by  NAME 
-                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
-                    Using   --installation=default  is equivalent to using
-                      --system .
-                </p></dd><dt><span class="term"><code class="option">--force</code></span></dt><dd><p>
-                    Remove remote even if its in use by installed apps or runtimes.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821839450160"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak --user remote-delete dried-raisins</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821834724112"></a><h2>See also</h2><p>
-                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-add-remote"><span class="citerefentry"><span class="refentrytitle">flatpak-add-remote</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-modify-remote"><span class="citerefentry"><span class="refentrytitle">flatpak-modify-remote</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-list-remotes"><span class="citerefentry"><span class="refentrytitle">flatpak-list-remotes</span>(1)</span></a>
-            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote-ls"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote-ls — Show available runtimes and applications</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak remote-ls</code>  [OPTION...]  REMOTE </p></div></div><div class="refsect1"><a id="idm139821838476096"></a><h2>Description</h2><p>
-            Shows runtimes and applications that are available in the
-            remote repository with the name  REMOTE .
-            You can find all configured remote repositories with flatpak remote-list.
-        </p><p>
-            Unless overridden with the --user or --installation options, this command
-            uses the default system-wide configuration.
-        </p></div><div class="refsect1"><a id="idm139821839134432"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
-                    Use the per-user configuration.
-                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
-                    Use the default system-wide configuration.
-                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
-                    Use a system-wide installation specified by  NAME 
-                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
-                    Using   --installation=default  is equivalent to using
-                      --system .
-                </p></dd><dt><span class="term"><code class="option">-d</code>, </span><span class="term"><code class="option">--show-details</code></span></dt><dd><p>
-                    Show arches, branches and commit ids, in addition to the names.
-                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
-                    Show only runtimes, omit applications.
+                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
+                    The architecture to uninstall, instead of the architecture of
+                    the host system.
                 </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
-                    Show only applications, omit runtimes.
-                </p></dd><dt><span class="term"><code class="option">--updates</code></span></dt><dd><p>
-                    Show only those which have updates available.
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    Show only those matching the specied architecture. By default, only
-                    supported architectures are shown. Use --arch=* to show all archtectures.
+                    Only look for an app with the given name.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Only look for a runtime with the given name.
+                </p></dd><dt><span class="term"><code class="option">--no-related</code></span></dt><dd><p>
+                    Don't uninstall related extensions, such as the locale data.
+                </p></dd><dt><span class="term"><code class="option">--force-remove</code></span></dt><dd><p>
+                    Remove files even if they're in use by a running application.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
                     Print OSTree debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
                     Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834798144"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak --user remote-ls --only-apps testrepo</strong></span>
-        </p><pre class="programlisting">
-org.gnome.Builder
-org.freedesktop.glxgears
-</pre></div><div class="refsect1"><a id="idm139821834795424"></a><h2>See also</h2><p>
-                <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-                <a class="citerefentry" href="#flatpak-remote-list"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-list</span>(1)</span></a>
-            </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-init"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-init — Initialize a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-init</code>  [OPTION...]  DIRECTORY   APPNAME   SDK   RUNTIME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm139821839945424"></a><h2>Description</h2><p>
-            Initializes a directory for building an application.
-             DIRECTORY  is the name of the directory.
-              APPNAME  is the application id of the app
-            that will be built.
-              SDK  and   RUNTIME 
-            specify the sdk and runtime that the application should be built
-            against and run in.
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm4122"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user uninstall org.gnome.GEdit</strong></span>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-update"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-update — Update an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak update</code>  [OPTION...] [REF...]</p></div><div class="cmdsynopsis"><p><code class="command">flatpak update</code>  [OPTION...]  --appstream  [REMOTE]</p></div></div><div class="refsect1"><a id="idm4152"></a><h2>Description</h2><p>
+            Updates applications and runtimes.  REF  is a reference to the
+            application or runtime to update. If no   REF  is given, everything
+            is updated, as well as appstream info for all remotes.
         </p><p>
-            The result of this command is that a <code class="filename">metadata</code>
-            file is created inside the given directory. Additionally, empty
-            <code class="filename">files</code> and <code class="filename">var</code> subdirectories
-            are created.
+            Each  REF  arguments is a full or partial indentifier in the
+            flatpak ref format, which looks like "(app|runtime)/ID/ARCH/BRANCH". All elements
+            except ID are optional and can be left out, including the slashes,
+            so most of the time you need only specify ID. Any part left out will be matched
+            against what is installed, and if there are multiple matches an error message
+            will list the alternatives.
         </p><p>
-            It is an error to run build-init on a directory that has already
-            been initialized as a build directory.
-        </p></div><div class="refsect1"><a id="idm139821834979440"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
+            By default this looks for both apps and runtimes with the given  REF ,
+            but you can limit this by using the --app or --runtime option, or by supplying the initial
+            element in the REF.
+        </p><p>
+            Normally, this command updates the application to the tip
+            of its branch. But it is possible to check out another commit,
+            with the --commit option.
+        </p><p>
+            Note that updating a runtime is different from installing
+            a different branch, and runtime updates are expected to keep
+            strict compatibility. If an application update does cause
+            a problem, it is possible to go back to the previous
+            version, with the --commit option.
+        </p><p>
+            Unless overridden with the --user or the --installation option, this command updates
+            the default system-wide installation.
+        </p></div><div class="refsect1"><a id="idm4164"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
                     Show help options and exit.
+                </p></dd><dt><span class="term"><code class="option">--user</code></span></dt><dd><p>
+                    Update a per-user installation.
+                </p></dd><dt><span class="term"><code class="option">--system</code></span></dt><dd><p>
+                    Update the default system-wide installation.
+                </p></dd><dt><span class="term"><code class="option">--installation=NAME</code></span></dt><dd><p>
+                    Updates a system-wide installation specified by  NAME 
+                    among those defined in <code class="filename">/etc/flatpak/installations.d/</code>.
+                    Using   --installation=default  is equivalent to using
+                      --system .
                 </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    The architecture to use.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--var=RUNTIME</code></span></dt><dd><p>
-                    Initialize var from the named runtime.
-                </p></dd><dt><span class="term"><code class="option">-w</code>, </span><span class="term"><code class="option">--writable-sdk</code></span></dt><dd><p>
-                    Initialize /usr with a copy of the sdk, which is writable during flatpak build. This can be used
-                    if you need to install build tools in /usr during the build. This is stored in the
-                    <code class="filename">usr</code> subdirectory of the app dir, but will not be part of the final
-                    app.
-                </p></dd><dt><span class="term"><code class="option">--tag=TAG</code></span></dt><dd><p>
-                    Add a tag to the metadata file.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--sdk-extension=EXTENSION</code></span></dt><dd><p>
-                    When using --writable-sdk, in addition to the sdk, also install the specified extension.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--sdk-dir</code></span></dt><dd><p>
-                    Specify a custom subdirectory to use instead of <code class="filename">usr</code> for --writable-sdk.
-                </p></dd><dt><span class="term"><code class="option">--update</code></span></dt><dd><p>
-                    Re-initialize the sdk and var, don't fail if already initialized.
-                </p></dd><dt><span class="term"><code class="option">--base=APP</code></span></dt><dd><p>
-                    Initialize the application with files from another specified application.
-                </p></dd><dt><span class="term"><code class="option">--base-version=VERSION</code></span></dt><dd><p>
-                    Specify the version to use for --base. If not specified, will default to
-                    "master".
-                </p></dd><dt><span class="term"><code class="option">--base-extension=EXTENSION</code></span></dt><dd><p>
-                    When using --base, also install the specified extension from the app.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--type=TYPE</code></span></dt><dd><p>
-                    This can be used to build different types of things. The default
-                    is "app" which is a regular app, but "runtime" creates a runtime
-                    based on an existing runtime, and "extension" creates an extension
-                    for an app or runtime.
-                </p></dd><dt><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834390672"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak build-init /build/my-app org.gnome.Sdk org.gnome.Platform 3.16</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821834388640"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build — Build in a directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build</code>  [OPTION...]  DIRECTORY  [COMMAND [ARG...]]</p></div></div><div class="refsect1"><a id="idm139821836260512"></a><h2>Description</h2><p>
-            Runs a build command in a directory.  DIRECTORY 
-            must have been initialized with <span class="command"><strong>flatpak build-init</strong></span>.
-        </p><p>
-            The sdk that is specified in the <code class="filename">metadata</code> file
-            in the directory is mounted at <code class="filename">/usr</code> and the
-            <code class="filename">files</code> and <code class="filename">var</code> subdirectories
-            are mounted at <code class="filename">/app</code> and <code class="filename">/var</code>,
-            respectively. They are writable, and their contents are preserved between
-            build commands, to allow accumulating build artifacts there.
-        </p></div><div class="refsect1"><a id="idm139821837796016"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
+                    The architecture to update for.
+                </p></dd><dt><span class="term"><code class="option">--subpath=PATH</code></span></dt><dd><p>
+                  Install only a subpath of the ref. This is mainly used to install a subset of locales.
+                  This can be added multiple times to install multiple subpaths.
+                  If this is not specified the subpaths specified at install time are reused.
+                </p></dd><dt><span class="term"><code class="option">--commit=COMMIT</code></span></dt><dd><p>
+                    Update to this commit, instead of the tip of the branch.
+                </p></dd><dt><span class="term"><code class="option">--no-deploy</code></span></dt><dd><p>
+                    Download the latest version, but don't deploy it.
+                </p></dd><dt><span class="term"><code class="option">--no-pull</code></span></dt><dd><p>
+                    Don't download the latest version, deploy whatever is locally available.
+                </p></dd><dt><span class="term"><code class="option">--no-related</code></span></dt><dd><p>
+                    Don't download related extensions, such as the locale data.
+                </p></dd><dt><span class="term"><code class="option">--no-deps</code></span></dt><dd><p>
+                    Don't update or install runtime dependencies when installing.
+                </p></dd><dt><span class="term"><code class="option">--app</code></span></dt><dd><p>
+                    Only look for an app with the given name.
+                </p></dd><dt><span class="term"><code class="option">--appstream</code></span></dt><dd><p>
+                    Update appstream for  REMOTE , or all remotes if no remote is specified.
+                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
+                    Only look for a runtime with the given name.
+                </p></dd><dt><span class="term"><code class="option">-y</code>, </span><span class="term"><code class="option">--assumeyes</code></span></dt><dd><p>
+                    Automatically answer yes to all questions (or pick the most prioritized answer). This is useful for automation.
+                </p></dd><dt><span class="term"><code class="option">--force-remove</code></span></dt><dd><p>
+                    Remove old files even if they're in use by a running application.
                 </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
                     Print debug information during command processing.
+                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
+                    Print OSTree debug information during command processing.
                 </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
                     Print version information and exit.
-                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
-                    Use the non-devel runtime that is specified in the application metadata instead of the devel runtime.
-                </p></dd><dt><span class="term"><code class="option">--bind-mount=DEST=SOURCE</code></span></dt><dd><p>
-                    Add a custom bind mount in the build namespace. Can be specified multiple times.
-                </p></dd><dt><span class="term"><code class="option">--build-dir=PATH</code></span></dt><dd><p>
-                    Start the build in this directory (default is in the current directory).
-                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
-                    Share a subsystem with the host session. This overrides
-                    the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
-                    Don't share a subsystem with the host session. This overrides
-                    the Context section from the application metadata.
-                    SUBSYSTEM must be one of: network, ipc.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
-                    Expose a well-known socket to the application. This overrides to
-                    the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
-                    Don't expose a well-known socket to the application. This overrides to
-                    the Context section from the application metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
-                    Expose a device to the application. This overrides to
-                    the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
-                    Don't expose a device to the application. This overrides to
-                    the Context section from the application metadata.
-                    DEVICE must be one of: dri, kvm, all.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
-                    Allow access to a specific feature. This updates
-                    the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
-                    This option can be used multiple times.
-                 </p><p>
-                    The <code class="code">devel</code> feature allows the application to
-                    access certain syscalls such as <code class="code">ptrace()</code>, and
-                <code class="code">perf_event_open()</code>.
-                </p><p>
-                    The <code class="code">multiarch</code> feature allows the application to
-                    execute programs compiled for an ABI other than the one supported
-                    natively by the system. For example, for the <code class="code">x86_64</code>
-                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
-                    well.
-                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
-                    Disallow access to a specific feature. This updates
-                    the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--filesystem=FILESYSTEM[:ro|:create]</code></span></dt><dd><p>
-                    Allow the application access to a subset of the filesystem.
-                    This overrides to the Context section from the application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
-                    xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
-                    path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
-                    The optional :ro suffix indicates that the location will be read-only.
-                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
-                    application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
-                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
-</p><pre class="programlisting">
-[Policy subsystem]
-key=v1;v2;
-</pre><p>
-                </p><p>
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
-                    Remove generic policy option. This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
-                    Set an environment variable in the application.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
-                    Allow the application to own the well-known name NAME on the session bus.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
-                    Allow the application to talk to the well-known name NAME on the session bus.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
-                    Allow the application to own the well-known name NAME on the system bus.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
-                    Allow the application to talk to the well-known name NAME on the system bus.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
-                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
-                    FILENAME a bind mount to the corresponding path in the per-application directory,
-                    allowing that location to be used for persistent data.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--sdk-dir=DIR</code></span></dt><dd><p>
-                  Normally if there is a <code class="filename">usr</code> directory in the build dir, this is used
-                  for the runtime files (this can be created by --writable-sdk or --type=runtime arguments
-                  to build-init). If you specify --sdk-dir this directoryname will be used instead.
-                  Use this if you passed --sdk-dir to build-init.
-                </p></dd><dt><span class="term"><code class="option">--metadata=FILE</code></span></dt><dd><p>
-                  Use the specified filename as metadata in the exported app instead of
-                  the default file (called <code class="filename">metadata</code>). This is useful
-                  if you build multiple things from a single build tree (such as both a
-                  platform and a sdk).
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834119920"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak build /build/my-app rpmbuild my-app.src.rpm</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821834117888"></a><h2>See also</h2><p>
+                </p></dd></dl></div></div><div class="refsect1"><a id="idm4274"></a><h2>Examples</h2><p>
+            <span class="command"><strong>$ flatpak --user update org.gnome.GEdit</strong></span>
+        </p></div><div class="refsect1"><a id="idm4278"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-finish"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-finish — Finalize a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-finish</code>  [OPTION...]  DIRECTORY </p></div></div><div class="refsect1"><a id="idm139821838825536"></a><h2>Description</h2><p>
-            Finalizes a build directory, to prepare it for exporting.
-             DIRECTORY  is the name of the directory.
+            <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-list"><span class="citerefentry"><span class="refentrytitle">flatpak-list</span>(1)</span></a>
+        </p></div></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="idm4290"></a>File Formats</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="refentrytitle"><a href="#flatpak-flatpakrepo">flatpakrepo</a></span><span class="refpurpose"> — Reference to a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakref">flatpakref</a></span><span class="refpurpose"> — Reference to a remote for an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-installation">flatpak installation</a></span><span class="refpurpose"> — Configuration for an installation location</span></dt><dt><span class="refentrytitle"><a href="#flatpak-metadata">flatpak metadata</a></span><span class="refpurpose"> — Information about an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote">flatpak remote</a></span><span class="refpurpose"> — Configuration for a remote</span></dt></dl></div><div class="refentry"><a id="flatpak-flatpakrepo"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-flatpakrepo — Reference to a remote</p></div><div class="refsect1"><a id="idm4308"></a><h2>Description</h2><p>
+            Flatpak uses flatpakrepo files to share information about remotes.
+            The <code class="filename">flatpakrepo</code> file contains enough information
+            to add the remote. Use the <span class="command"><strong>flatpak remote-add --from</strong></span>
+            command to do so.
         </p><p>
-            The result of this command is that desktop files, icons and
-            D-Bus service files from the <code class="filename">files</code> subdirectory
-            are copied to a new <code class="filename">export</code> subdirectory. In the
-            <code class="filename">metadata</code> file, the command key is set in the
-            [Application] group, and the supported keys in the [Environment]
-            group are set according to the options.
+            flatpakrepo files may also contain additional information that is useful
+            when displaying a remote to the user, e.g. in an app store.
         </p><p>
-            You should review the exported files and the application metadata
-            before creating and distributing an application bundle.
-        </p><p>
-            It is an error to run build-finish on a directory that has not
-            been initialized as a build directory, or has already been finalized.
-        </p></div><div class="refsect1"><a id="idm139821834628640"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--command=COMMAND</code></span></dt><dd><p>
-                    The command to use. If this option is not specified,
-                    the first executable found in <code class="filename">files/bin</code>
-                    is used.
-                </p></dd><dt><span class="term"><code class="option">--require-version=MAJOR.MINOR.MICRO</code></span></dt><dd><p>
-                    Require this version of later of flatpak to install/update to this build.
-                </p></dd><dt><span class="term"><code class="option">--share=SUBSYSTEM</code></span></dt><dd><p>
-                    Share a subsystem with the host session. This updates
-                    the [Context] group in the metadata.
-                    SUBSYSTEM must be one of: network, ipc.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--unshare=SUBSYSTEM</code></span></dt><dd><p>
-                    Don't share a subsystem with the host session. This updates
-                    the [Context] group in the metadata.
-                    SUBSYSTEM must be one of: network, ipc.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--socket=SOCKET</code></span></dt><dd><p>
-                    Expose a well known socket to the application. This updates
-                    the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nosocket=SOCKET</code></span></dt><dd><p>
-                    Don't expose a well known socket to the application. This updates
-                    the [Context] group in the metadata.
-                    SOCKET must be one of: x11, wayland, pulseaudio, system-bus, session-bus.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--device=DEVICE</code></span></dt><dd><p>
-                    Expose a device to the application. This updates
-                    the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, all.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nodevice=DEVICE</code></span></dt><dd><p>
-                    Don't expose a device to the application. This updates
-                    the [Context] group in the metadata.
-                    DEVICE must be one of: dri, kvm, all.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--allow=FEATURE</code></span></dt><dd><p>
-                    Allow access to a specific feature. This updates
-                    the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
-                    This option can be used multiple times.
-                 </p><p>
-                    The <code class="code">devel</code> feature allows the application to
-                    access certain syscalls such as <code class="code">ptrace()</code>, and
-                <code class="code">perf_event_open()</code>.
-                </p><p>
-                    The <code class="code">multiarch</code> feature allows the application to
-                    execute programs compiled for an ABI other than the one supported
-                    natively by the system. For example, for the <code class="code">x86_64</code>
-                    architecture, 32-bit <code class="code">x86</code> binaries will be allowed as
-                    well.
-                </p></dd><dt><span class="term"><code class="option">--disallow=FEATURE</code></span></dt><dd><p>
-                    Disallow access to a specific feature. This updates
-                    the [Context] group in the metadata.
-                    FEATURE must be one of: devel, multiarch.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--filesystem=FS</code></span></dt><dd><p>
-                    Allow the application access to a subset of the filesystem.
-                    This updates the [Context] group in the metadata.
-                    FS can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos, xdg-run,
-                    xdg-config, xdg-cache, xdg-data, an absolute path, or a homedir-relative
-                    path like ~/dir or paths relative to the xdg dirs, like xdg-download/subdir.
-                    The optional :ro suffix indicates that the location will be read-only.
-                    The optional :create suffix indicates that the location will be read-write and created if it doesn't exist.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--nofilesystem=FILESYSTEM</code></span></dt><dd><p>
-                    Remove access to the specified subset of the filesystem from
-                    the application. This overrides to the Context section from the
-                    application metadata.
-                    FILESYSTEM can be one of: home, host, xdg-desktop, xdg-documents, xdg-download
-                    xdg-music, xdg-pictures, xdg-public-share, xdg-templates, xdg-videos,
-                    an absolute path, or a homedir-relative path like ~/dir.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--add-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
-                    Add generic policy option. For example, "--add-policy=subsystem.key=v1 --add-policy=subsystem.key=v2" would map to this metadata:
-</p><pre class="programlisting">
-[Policy subsystem]
-key=v1;v2;
-</pre><p>
-                </p><p>
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--remove-policy=SUBSYSTEM.KEY=VALUE</code></span></dt><dd><p>
-                    Remove generic policy option. This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--env=VAR=VALUE</code></span></dt><dd><p>
-                    Set an environment variable in the application.
-                    This updates the [Environment] group in the metadata.
-                    This overrides to the Context section from the application metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--own-name=NAME</code></span></dt><dd><p>
-                    Allow the application to own the well known name NAME on the session bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
+           The filename extension commonly used for flatpakrepo files is <code class="filename">.flatpakrepo</code>.
+        </p></div><div class="refsect1"><a id="idm4316"></a><h2>File format</h2><p>
+            The flatpakrepo file is using the same .ini file format that is used for
+            systemd unit files or application .desktop files.
+        </p><div class="refsect2"><a id="idm4319"></a><h3>[Flatpak Repo]</h3><p>
+                All the information is contained in the [Flatpak Repo] group.
+            </p><p>
+                The following keys can be present in this group:
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Version</code> (uint64)</span></dt><dd><p>The version of the file format, must be 1 if present.</p></dd><dt><span class="term"><code class="option">Url</code> (string)</span></dt><dd><p>The url for the remote. This key is mandatory.</p></dd><dt><span class="term"><code class="option">GPGKey</code> (string)</span></dt><dd><p>The base64-encoded gpg key for the remote.</p></dd><dt><span class="term"><code class="option">DefaultBranch</code> (string)</span></dt><dd><p>The default branch to use for this remote.</p></dd><dt><span class="term"><code class="option">Title</code> (string)</span></dt><dd><p>The title of the remote. This should be a user-friendly name that can be displayed e.g. in an app store.</p></dd><dt><span class="term"><code class="option">Comment</code> (string)</span></dt><dd><p>A short summary of the remote, for display e.g. in an app store.</p></dd><dt><span class="term"><code class="option">Description</code> (string)</span></dt><dd><p>A longer description of the remote, for display e.g. in an app store..</p></dd><dt><span class="term"><code class="option">Icon</code> (string)</span></dt><dd><p>The url for an icon that can be used to represent the remote.</p></dd><dt><span class="term"><code class="option">Homepage</code> (string)</span></dt><dd><p>The url of a webpage describing the remote.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm4369"></a><h2>Example</h2><pre class="programlisting">
+[Flatpak Repo]
+Title=GEdit
+Url=http://sdk.gnome.org/repo-apps/
+GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
 
-                    This updates the [Session Bus Policy] group in the metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--talk-name=NAME</code></span></dt><dd><p>
-                    Allow the application to talk to the well known name NAME on the session bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
-                    This updates the [Session Bus Policy] group in the metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--system-own-name=NAME</code></span></dt><dd><p>
-                    Allow the application to own the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to own all matching names.
-                    This updates the [System Bus Policy] group in the metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--system-talk-name=NAME</code></span></dt><dd><p>
-                    Allow the application to talk to the well known name NAME on the system bus.
-                    If NAME ends with .*, it allows the application to talk to all matching names.
-                    This updates the [System Bus Policy] group in the metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--persist=FILENAME</code></span></dt><dd><p>
-                    If the application doesn't have access to the real homedir, make the (homedir-relative) path
-                    FILENAME a bind mount to the corresponding path in the per-application directory,
-                    allowing that location to be used for persistent data.
-                    This updates the [Context] group in the metadata.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--runtime=RUNTIME</code>, </span><span class="term"><code class="option">--sdk=SDK</code></span></dt><dd><p>
-                  Change the runtime or sdk used by the app to the specified partial ref. Unspecified parts
-                  of the ref are taken from the old values or defaults.
-                </p></dd><dt><span class="term"><code class="option">--metadata=GROUP=KEY[=VALUE]</code></span></dt><dd><p>
-                  Set a generic key in the metadata file. If value is left out it will
-                  be set to "true".
-                </p></dd><dt><span class="term"><code class="option">--extension=NAME=VARIABLE[=VALUE]</code></span></dt><dd><p>
-                  Add extension point info.
-                </p></dd><dt><span class="term"><code class="option">--extra-data=NAME:SHA256:DOWNLOAD-SIZE:INSTALL-SIZE:URL</code></span></dt><dd><p>
-                    Adds information about extra data uris to the app. These will be downloaded
-                    and verified by the client when the app is installed and placed in the
-                    /app/extra directory. You can also supply an /app/bin/apply_extra script
-                    that will be run after the files are downloaded.
-                </p></dd><dt><span class="term"><code class="option">--no-exports</code></span></dt><dd><p>
-                    Don't look for exports in the build.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834064016"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak build-finish /build/my-app --socket=x11 --share=ipc</strong></span>
-        </p><pre class="programlisting">
-Exporting share/applications/gnome-calculator.desktop
-Exporting share/dbus-1/services/org.gnome.Calculator.SearchProvider.service
-More than one executable
-Using gcalccmd as command
-Please review the exported files and the metadata
-</pre></div><div class="refsect1"><a id="idm139821834061040"></a><h2>See also</h2><p>
+</pre></div><div class="refsect1"><a id="idm4372"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-export — Create a repository from a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-export</code>  [OPTION...]  LOCATION   DIRECTORY  [BRANCH]</p></div></div><div class="refsect1"><a id="idm139821835968416"></a><h2>Description</h2><p>
-            Creates or updates a repository with an application build.
-             LOCATION  is the location of the
-            repository.   DIRECTORY  must be a
-            finalized build directory. If   BRANCH 
-            is not specified, it is assumed to be "master".
+            <a class="citerefentry" href="#flatpak-remote-add"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span></a>,
+            <a class="citerefentry" href="#flatpak-flatpakref"><span class="citerefentry"><span class="refentrytitle">flatpak-flatpakref</span>(5)</span></a>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-flatpakref"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-flatpakref — Reference to a remote for an application or runtime</p></div><div class="refsect1"><a id="idm4400"></a><h2>Description</h2><p>
+            Flatpak uses flatpakref files to share information about a remote for
+            a single application. The <code class="filename">flatpakref</code> file contains
+            enough information to add the remote and install the application.
+            Use the <span class="command"><strong>flatpak install --from</strong></span> command to do so.
         </p><p>
-            If  LOCATION  exists, it is assumed to
-            be an OSTree repository, otherwise a new OSTree repository is
-            created at this location. The repository can be inspected with
-            the <span class="command"><strong>ostree</strong></span> tool.
+            flatpakref files may also contain additional information that is useful
+            when displaying the application to the user, e.g. in an app store.
         </p><p>
-            The contents of  DIRECTORY  are committed
-            on the branch with name <code class="literal">app/APPNAME/ARCH/BRANCH</code>,
-            where ARCH is the architecture of the runtime that the application
-            is using. A commit filter is used to enforce that only the contents
-            of the <code class="filename">files/</code> and <code class="filename">export/</code>
-            subdirectories and the <code class="filename">metadata</code> file are included
-            in the commit, anything else is ignored.
+           The filename extension commonly used for flatpakref files is <code class="filename">.flatpakref</code>.
         </p><p>
-            The build-update-repo command should be used to update repository
-            metadata whenever application builds are added to a repository.
-        </p></div><div class="refsect1"><a id="idm139821836918720"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--subject=SUBJECT</code></span></dt><dd><p>
-                    One line subject for the commit message.
-                </p></dd><dt><span class="term"><code class="option">-b</code>, </span><span class="term"><code class="option">--body=BODY</code></span></dt><dd><p>
-                    Full description for the commit message.
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    Specify the architecture component of the branch to export. Only host compatible architectures can be specified.
-                </p></dd><dt><span class="term"><code class="option">--exclude=PATTERN</code></span></dt><dd><p>
-                    Exclude files matching PATTERN from the commit.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--include=PATTERN</code></span></dt><dd><p>
-                    Don't exclude files matching PATTERN from the commit, even if they match the --export patterns.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--metadata=FILENAME</code></span></dt><dd><p>
-                  Use the specified filename as metadata in the exported app instead of
-                  the default file (called <code class="filename">metadata</code>). This is useful
-                  if you want to commit multiple things from a single build tree, typically
-                  used in combination with --files and --exclude.
-                </p></dd><dt><span class="term"><code class="option">--files=SUBDIR</code></span></dt><dd><p>
-                  Use the files in the specified subdirectory as the file contents, rather
-                  than the regular <code class="filename">files</code> directory.
-                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
-                    Run appstream-builder and to update the appstream branch after build.
-                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
-                    Don't update the summary file after the new commit is added. This means
-                    the repository will not be useful for serving over http until build-repo-update
-                    has been run. This is useful is you want to do multiple repo operations before
-                    finally updating the summary.
-                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
-                    Sign the commit with this GPG key.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
-                    GPG Homedir to use when looking for keyrings
-                </p></dd><dt><span class="term"><code class="option">-r</code>, </span><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
-                    Export a runtime instead for an app (this uses the usr subdir as files).
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834095920"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak build-export ~/repos/gnome-calculator/ ~/build/gnome-calculator/ org.gnome.Calculator</strong></span>
-        </p><pre class="programlisting">
-Commit: 9d0044ea480297114d03aec85c3d7ae3779438f9d2cb69d717fb54237acacb8c
-Metadata Total: 605
-Metadata Written: 5
-Content Total: 1174
-Content Written: 1
-Content Bytes Written: 305
-</pre></div><div class="refsect1"><a id="idm139821834092896"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
+           A flatpakref file can also refer to a remote for a runtime.
+        </p></div><div class="refsect1"><a id="idm4409"></a><h2>File format</h2><p>
+            The flatpakref file is using the same .ini file format that is used for
+            systemd unit files or application .desktop files.
+        </p><div class="refsect2"><a id="idm4412"></a><h3>[Flatpak Ref]</h3><p>
+                All the information is contained in the [Flatpak Ref] group.
+            </p><p>
+                The following keys can be present in this group:
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Version</code> (uint64)</span></dt><dd><p>The version of the file format, must be 1 if present.</p></dd><dt><span class="term"><code class="option">Name</code> (string)</span></dt><dd><p>The fully qualified name of the runtime that is used by the application. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Url</code> (string)</span></dt><dd><p>The url for the remote. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Branch</code> (string)</span></dt><dd><p>The name of the branch from which to install the application or runtime. If this key is not specified, the "master" branch is used.</p></dd><dt><span class="term"><code class="option">Title</code> (string)</span></dt><dd><p>The title of the application or runtime. This should be a user-friendly name that can be displayed e.g. in an app store.</p></dd><dt><span class="term"><code class="option">Comment</code> (string)</span></dt><dd><p>A short summary of the application or runtime, for display e.g. in an app store.</p></dd><dt><span class="term"><code class="option">Description</code> (string)</span></dt><dd><p>A longer description of the application or runtime, for display e.g. in an app store..</p></dd><dt><span class="term"><code class="option">Icon</code> (string)</span></dt><dd><p>The url for an icon that can be used to represent the application or runtime.</p></dd><dt><span class="term"><code class="option">Homepage</code> (string)</span></dt><dd><p>The url of a webpage describing the application or runtime.</p></dd><dt><span class="term"><code class="option">IsRuntime</code> (boolean)</span></dt><dd><p>Whether this file refers to a runtime. If this key is not specified, the file is assumed to refer to an application.</p></dd><dt><span class="term"><code class="option">GPGKey</code> (string)</span></dt><dd><p>The base64-encoded gpg key for the remote.</p></dd><dt><span class="term"><code class="option">RuntimeRepo</code> (string)</span></dt><dd><p>The url for a .flatpakref file for the runtime.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm4477"></a><h2>Example</h2><pre class="programlisting">
+[Flatpak Ref]
+Title=GEdit
+Name=org.gnome.gedit
+Branch=stable
+Url=http://sdk.gnome.org/repo-apps/
+IsRuntime=False
+GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
+</pre></div><div class="refsect1"><a id="idm4480"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-sign"><span class="citerefentry"><span class="refentrytitle">flatpak-build-sign</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-bundle"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-bundle — Create a single-file bundle from a local repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-bundle</code>  [OPTION...]  LOCATION   FILENAME   NAME  [BRANCH]</p></div></div><div class="refsect1"><a id="idm139821835045632"></a><h2>Description</h2><p>
-            Creates a single-file named  FILENAME 
-            for the application (or runtime) named   NAME 
-            in the repository at   LOCATION . If
-            a   BRANCH  is specified, this branch of
-            the application is used.
+            <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>
+            <a class="citerefentry" href="#flatpak-flatpakrepo"><span class="citerefentry"><span class="refentrytitle">flatpak-flatpakrepo</span>(5)</span></a>,
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-installation"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-installation — Configuration for an installation location</p></div><div class="refsect1"><a id="idm4508"></a><h2>Description</h2><p>
+            flatpak can operate in system-wide or per-user mode. The system-wide data
+            is located in <code class="filename">$prefix/var/lib/flatpak/</code>, and the per-user data is in
+            <code class="filename">$HOME/.local/share/flatpak/</code>.
         </p><p>
-            The format of the bundle file is that of an ostree static delta
-            (against an empty base) with some flatpak specific metadata for
-            the application icons and appdata.
-        </p></div><div class="refsect1"><a id="idm139821837143360"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
-                    Export a runtime instead of an application.
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    The arch to create a bundle for.
-                </p></dd><dt><span class="term"><code class="option">--repo-url=URL</code></span></dt><dd><p>
-                    The URL for the repository from which the
-                    application can be updated. Installing the
-                    bundle will automatically configure a remote
-                    for this URL.
-                </p></dd><dt><span class="term"><code class="option">--runtime-repo=URL</code></span></dt><dd><p>
-                  The URL for a .flatpakrepo file that contains
-                  the information about the repository that supplies
-                  the runtimes required by the app.
-                </p></dd><dt><span class="term"><code class="option">--gpg-keys=FILE</code></span></dt><dd><p>
-                    Add the GPG key from FILE (use - for stdin).
-                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
-                    GPG Homedir to use when looking for keyrings.
-                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
-                    Export to an OCI image instead of a Flatpak bundle.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821835206720"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-import-bundle"><span class="citerefentry"><span class="refentrytitle">flatpak-build-import-bundle</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-import-bundle"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-import-bundle — Import a file bundle into a local repository</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-import-bundle</code>  [OPTION...]  LOCATION   FILENAME </p></div></div><div class="refsect1"><a id="idm139821837247312"></a><h2>Description</h2><p>
-            Imports a bundle from a file named  FILENAME 
-            into the repository at   LOCATION .
-        </p><p>
-            The format of the bundle file is that generated by build-bundle.
-        </p></div><div class="refsect1"><a id="idm139821834201584"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ref=REF</code></span></dt><dd><p>
-                    Override the ref specified in the bundle.
-                </p></dd><dt><span class="term"><code class="option">--oci</code></span></dt><dd><p>
-                    Import an OCI image instead of a Flatpak bundle.
-                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
-                    Run appstream-builder and to update the appstream branch after build.
-                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
-                    Don't update the summary file after the new commit is added. This means
-                    the repository will not be useful for serving over http until build-repo-update
-                    has been run. This is useful is you want to do multiple repo operations before
-                    finally updating the summary.
-                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
-                    Sign the commit with this GPG key.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
-                    GPG Homedir to use when looking for keyrings
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834237472"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-bundle"><span class="citerefentry"><span class="refentrytitle">flatpak-build-bundle</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-export"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-sign — Sign an application or runtime</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-sign</code>  [OPTION...]  LOCATION   ID  [BRANCH]</p></div></div><div class="refsect1"><a id="idm139821835552032"></a><h2>Description</h2><p>
-            Signs the commit for a specified application or runtime in
-            a local repository.   LOCATION  is
-            the location of the repository.   ID  is the name of the application, or
-            runtime if --runtime is specified. If   BRANCH  is not specified, it is
-            assumed to be "master".
-        </p><p>
-            Applications can also be signed during build-export, but
-            it is sometimes useful to add additional signatures later.
-        </p></div><div class="refsect1"><a id="idm139821834681168"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
-                    Sign the commit with this GPG key.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
-                    GPG Homedir to use when looking for keyrings
-                </p></dd><dt><span class="term"><code class="option">--runtime</code></span></dt><dd><p>
-                    Sign a runtime instead of an app.
-                </p></dd><dt><span class="term"><code class="option">--arch=ARCH</code></span></dt><dd><p>
-                    The architecture to use.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834815584"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak build-sign --gpg-sign=D8BA6573DDD2418027736F1BC33B315E53C1E9D6 /some/repo org.my.App</strong></span>
-        </p></div><div class="refsect1"><a id="idm139821834813440"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-update-repo"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-update-repo — Create a repository from a build directory</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-update-repo</code>  [OPTION...]  LOCATION </p></div></div><div class="refsect1"><a id="idm139821838595920"></a><h2>Description</h2><p>
-            Updates repository metadata for the repository at
-             LOCATION . This command generates
-            an OSTree summary file that lists the contents of the repository.
-            The summary is used by flatpak repo-contents and other commands
-            to display the contents of remote repositories.
-        </p><p>
-            After this command,  LOCATION  can be
-            used as the repository location for flatpak add-repo, either by
-            exporting it over http, or directly with a file: url.
-        </p></div><div class="refsect1"><a id="idm139821834602128"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--title=TITLE</code></span></dt><dd><p>
-                    A title for the repository, e.g. for display in a UI.
-                    The title is stored in the repository summary.
-                </p></dd><dt><span class="term"><code class="option">--default-branch=BRANCH</code></span></dt><dd><p>
-                    A default branch for the repository, mainly for use in a UI.
-                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
-                    Sign the commit with this GPG key.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
-                    GPG Homedir to use when looking for keyrings
-                </p></dd><dt><span class="term"><code class="option">--generate-static-deltas</code></span></dt><dd><p>
-                  Generate static deltas for all references. This generates from-empty and
-                  delta static files that allow for faster download.
-                </p></dd><dt><span class="term"><code class="option">--prune</code></span></dt><dd><p>
-                    Remove unreferenced objects in repo.
-                </p></dd><dt><span class="term"><code class="option">--prune-depth</code></span></dt><dd><p>
-                    Only keep at most this number of old versions for any particular ref. Default is -1 which means infinite.
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821835020064"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-repo-contents"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-contents</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-export"><span class="citerefentry"><span class="refentrytitle">flatpak-build-export</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-build-commit-from"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-build-commit-from — Create new commits based on existing one (possibly from another repository)</p></div><div class="refsynopsisdiv"><h2>Synopsis</h2><div class="cmdsynopsis"><p><code class="command">flatpak build-commit-from</code>  [OPTION...]  DST-REPO   DST-REF... </p></div></div><div class="refsect1"><a id="idm139821839080752"></a><h2>Description</h2><p>
-            Creates new commits on the  DST-REF 
-            branch in the   DST-REPO , with the
-            contents (and most of the metadata) taken from another
-            branch, either from another repo, or from another branch in
-            the same repository.
-        </p><p>
-            This command is very useful when you want to maintain a branch
-            with a clean history that has no unsigned or broken commits.
-            For instance, you can import the head from a different repository
-            from an automatic builder when you've verified that it worked.
-            The new commit will have no parents or signatures from the
-            autobuilder, and can be properly signed with the official
-            key.
-        </p></div><div class="refsect1"><a id="idm139821834301680"></a><h2>Options</h2><p>The following options are understood:</p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">-h</code>, </span><span class="term"><code class="option">--help</code></span></dt><dd><p>
-                    Show help options and exit.
-                </p></dd><dt><span class="term"><code class="option">--src-repo=SRC-REPO</code></span></dt><dd><p>
-                    The (local) repository to pull the source branch from. Defaults to the
-                    destination repository.
-                </p></dd><dt><span class="term"><code class="option">--src-ref=SRC-REF</code></span></dt><dd><p>
-                    The branch to use as the source for the new commit. Defaults to the same
-                    as the destination ref, which is useful only if a different source repo
-                    has been specified.
-                </p></dd><dt><span class="term"><code class="option">--untrusted</code></span></dt><dd><p>
-                    The source repostory is not trusted, all objects are copied (not hardlinked) and
-                    all checksums are verified.
-                </p></dd><dt><span class="term"><code class="option">-s</code>, </span><span class="term"><code class="option">--subject=SUBJECT</code></span></dt><dd><p>
-                    One line subject for the commit message. If not specified, will be taken from the source commit.
-                </p></dd><dt><span class="term"><code class="option">-b</code>, </span><span class="term"><code class="option">--body=BODY</code></span></dt><dd><p>
-                    Full description for the commit message. If not specified, will be taken from the source commit.
-                </p></dd><dt><span class="term"><code class="option">--update-appstream</code></span></dt><dd><p>
-                    Run appstream-builder and to update the appstream branch after build.
-                </p></dd><dt><span class="term"><code class="option">--no-update-summary</code></span></dt><dd><p>
-                    Don't update the summary file after the new commit is added. This means
-                    the repository will not be useful for serving over http until build-repo-update
-                    has been run. This is useful is you want to do multiple repo operations before
-                    finally updating the summary.
-                </p></dd><dt><span class="term"><code class="option">--force</code></span></dt><dd><p>
-                    Create new commit even if the content didn't change from the existing branch head.
-                </p></dd><dt><span class="term"><code class="option">--gpg-sign=KEYID</code></span></dt><dd><p>
-                    Sign the commit with this GPG key.
-                    This option can be used multiple times.
-                </p></dd><dt><span class="term"><code class="option">--gpg-homedir=PATH</code></span></dt><dd><p>
-                    GPG Homedir to use when looking for keyrings
-                </p></dd><dt><span class="term"><code class="option">-v</code>, </span><span class="term"><code class="option">--verbose</code></span></dt><dd><p>
-                    Print debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--ostree-verbose</code></span></dt><dd><p>
-                    Print OSTree debug information during command processing.
-                </p></dd><dt><span class="term"><code class="option">--version</code></span></dt><dd><p>
-                    Print version information and exit.
-                </p></dd></dl></div></div><div class="refsect1"><a id="idm139821834160928"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak build-export ~/repos/gnome-calculator/ ~/build/gnome-calculator/ org.gnome.Calculator</strong></span>
-        </p><pre class="programlisting">
-Commit: 9d0044ea480297114d03aec85c3d7ae3779438f9d2cb69d717fb54237acacb8c
-Metadata Total: 605
-Metadata Written: 5
-Content Total: 1174
-Content Written: 1
-Content Bytes Written: 305
-</pre></div><div class="refsect1"><a id="idm139821834157904"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#ostree"><span class="citerefentry"><span class="refentrytitle">ostree</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-init"><span class="citerefentry"><span class="refentrytitle">flatpak-build-init</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build"><span class="citerefentry"><span class="refentrytitle">flatpak-build</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-finish"><span class="citerefentry"><span class="refentrytitle">flatpak-build-finish</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-build-sign"><span class="citerefentry"><span class="refentrytitle">flatpak-build-sign</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-repo-update"><span class="citerefentry"><span class="refentrytitle">flatpak-repo-update</span>(1)</span></a>
-        </p></div></div></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="idm139821843047968"></a>File Formats</h2></div></div></div><div class="toc"><p><strong>Table of Contents</strong></p><dl class="toc"><dt><span class="refentrytitle"><a href="#flatpak-metadata">flatpak metadata</a></span><span class="refpurpose"> — Information about an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakrepo">flatpakrepo</a></span><span class="refpurpose"> — Reference to a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-flatpakref">flatpakref</a></span><span class="refpurpose"> — Reference to a remote for an application or runtime</span></dt><dt><span class="refentrytitle"><a href="#flatpak-manifest">flatpak manifest</a></span><span class="refpurpose"> — Information for building an application</span></dt><dt><span class="refentrytitle"><a href="#flatpak-remote">flatpak remote</a></span><span class="refpurpose"> — Configuration for a remote</span></dt><dt><span class="refentrytitle"><a href="#flatpak-installation">flatpak installation</a></span><span class="refpurpose"> — Configuration for an installation location</span></dt></dl></div><div class="refentry"><a id="flatpak-metadata"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-metadata — Information about an application or runtime</p></div><div class="refsect1"><a id="idm139821836568144"></a><h2>Description</h2><p>
+            In addition to the default installation locations, more system-wide installations
+            can be defined via configuration files <code class="filename">/etc/flatpak/installations.d/</code>,
+            which must have the .conf extension and follow the format described below.
+        </p></div><div class="refsect1"><a id="idm4515"></a><h2>File format</h2><p>
+            The installation config file format is using the same .ini file format that is used
+            for systemd unit files or application .desktop files.
+        </p><div class="refsect2"><a id="idm4518"></a><h3>[Installation …]</h3><p>
+                All the configuration for the the installation location with name NAME is contained
+                in the [Installation "NAME"] group.
+            </p><p>
+                The following keys are recognized:
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Path</code> (string)</span></dt><dd><p>The path for this installation. This key is mandatory.</p></dd><dt><span class="term"><code class="option">DisplayName</code> (string)</span></dt><dd><p>The name to use when showing this installation in the UI.</p></dd><dt><span class="term"><code class="option">Priority</code> (integer)</span></dt><dd><p>A priority for this installation.</p></dd><dt><span class="term"><code class="option">StorageType</code> (string)</span></dt><dd><p>The type of storage used for this installation. Possible values include: mmc, sdcard, harddisk.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm4543"></a><h2>Examples</h2><pre class="programlisting">
+[Installation "extra"]
+Path=/location/of/sdcard
+DisplayName=Extra Installation
+StorageType=sdcard
+</pre></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-metadata"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-metadata — Information about an application or runtime</p></div><div class="refsect1"><a id="idm4562"></a><h2>Description</h2><p>
             Flatpak uses metadata files to describe applications and runtimes.
             The <code class="filename">metadata</code> file for a deployed application or
             runtime is placed in the toplevel deploy directory. For example, the
@@ -2011,16 +2071,33 @@ Content Bytes Written: 305
             run command, or permanently with the flatpak override command.
         </p><p>
             A metadata file describing the effective configuration is available
-            inside the running sandbox at <code class="filename">/run/user/$UID/flatpak-info</code>.
-        </p></div><div class="refsect1"><a id="idm139821834904480"></a><h2>File format</h2><p>
+            inside the running sandbox at <code class="filename">/.flatpak-info</code>.
+            For compatibility with older Flatpak versions,
+            <code class="filename">/run/user/$UID/flatpak-info</code> is a symbolic
+            link to the same file.
+        </p></div><div class="refsect1"><a id="idm4571"></a><h2>File format</h2><p>
             The metadata file is using the same .ini file format that is used for
             systemd unit files or application .desktop files.
-        </p><div class="refsect2"><a id="idm139821839037296"></a><h3>[Application] or [Runtime]</h3><p>
+        </p><div class="refsect2"><a id="idm4574"></a><h3>[Application] or [Runtime]</h3><p>
                 Metadata for applications starts with an [Application] group,
                 metadata for runtimes with a [Runtime] group.
             </p><p>
                 The following keys can be present in these groups:
-            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">name</code> (string)</span></dt><dd><p>The name of the application or runtime. This key is mandatory.</p></dd><dt><span class="term"><code class="option">runtime</code> (string)</span></dt><dd><p>The fully qualified name of the runtime that is used by the application. This key is mandatory for applications.</p></dd><dt><span class="term"><code class="option">sdk</code> (string)</span></dt><dd><p>The fully qualified name of the sdk that matches the runtime.</p></dd><dt><span class="term"><code class="option">command</code> (string)</span></dt><dd><p>The command to run. Only relevant for applications.</p></dd></dl></div></div><div class="refsect2"><a id="idm139821834630912"></a><h3>[Context]</h3><p>
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">name</code> (string)</span></dt><dd><p>The name of the application or runtime. This key is mandatory.</p></dd><dt><span class="term"><code class="option">runtime</code> (string)</span></dt><dd><p>The fully qualified name of the runtime that is used by the application. This key is mandatory for applications.</p></dd><dt><span class="term"><code class="option">sdk</code> (string)</span></dt><dd><p>
+                        The fully qualified name of the sdk that matches the
+                        runtime. Available since 0.1.</p></dd><dt><span class="term"><code class="option">command</code> (string)</span></dt><dd><p>
+                        The command to run. Only relevant for applications.
+                        Available since 0.1.
+                      </p></dd><dt><span class="term"><code class="option">required-flatpak</code> (string)</span></dt><dd><p>
+                        The required version of Flatpak to run this application
+                        or runtime. For applications, this was available since
+                        0.8.0. For runtimes, this was available since 0.9.1,
+                        and backported to 0.8.3 for the 0.8.x branch.
+                    </p></dd><dt><span class="term"><code class="option">tags</code> (string list)</span></dt><dd><p>
+                        Tags to include in AppStream XML.
+                        Available since 0.4.12.
+                        
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm4609"></a><h3>[Context]</h3><p>
                 This group determines various system resources that may be shared
                 with the application when it is run in a flatpak sandbox.
             </p><p>
@@ -2028,6 +2105,7 @@ Content Bytes Written: 305
             </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">shared</code> (list)</span></dt><dd><p>
                         List of subsystems to share with the host system.
                         Possible subsystems: network, ipc.
+                        Available since 0.3.
                     </p></dd><dt><span class="term"><code class="option">sockets</code> (list)</span></dt><dd><p>
                         List of well-known sockets to make available in the sandbox.
                         Possible sockets: x11, wayland, pulseaudio, session-bus, system-bus.
@@ -2035,23 +2113,135 @@ Content Bytes Written: 305
                         well-known environment variables like DISPLAY or
                         DBUS_SYSTEM_BUS_ADDRESS to let the application
                         find sockets that are not in a fixed location.
+                        Available since 0.3.
                     </p></dd><dt><span class="term"><code class="option">devices</code> (list)</span></dt><dd><p>
                         List of devices to make available in the sandbox.
-                        Possible values: dri, kvm, all.
+                        Possible values:
+                        </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">dri</code></span></dt><dd><p>
+                                Graphics direct rendering
+                                (<code class="filename">/dev/dri</code>).
+                                Available since 0.3.
+                            </p></dd><dt><span class="term"><code class="option">kvm</code></span></dt><dd><p>
+                                Virtualization
+                                (<code class="filename">/dev/kvm</code>).
+                                Available since 0.6.12.
+                            </p></dd><dt><span class="term"><code class="option">all</code></span></dt><dd><p>
+                                All device nodes in <code class="filename">/dev</code>.
+                                Available since 0.6.6.
+                            </p></dd></dl></div><p>
                     </p></dd><dt><span class="term"><code class="option">filesystems</code> (list)</span></dt><dd><p>
                         List of filesystem subsets to make available to the
-                        application. Possible values: home, host, xdg-desktop,
-                        xdg-documents, xdg-download xdg-music, xdg-pictures,
-                        xdg-public-share, xdg-templates, xdg-videos, xdg-run,
-                        xdg-config, xdg-cache, xdg-data,
-                        an absolute path, or a homedir-relative path like
-                        ~/dir or paths relative to the xdg dirs, like
-                        xdg-download/subdir. The xdg-* arguments can also
-                        specify a subdirectory, such as xdg-pictures/screenshots.
-                        Each entry can have a suffix of
-                        :ro, :rw or :create to indicate if the path should be shared
-                        read-only, read-write or read-write + create if needed
-                        (default is read-write).
+                        application. Possible values:
+                        </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">home</code></span></dt><dd><p>
+                                The entire home directory.
+                                Available since 0.3.
+                            </p></dd><dt><span class="term"><code class="option">host</code></span></dt><dd><p>
+                                The entire host file system, except for
+                                directories that are handled specially by
+                                Flatpak.
+                                In particular, this shares
+                                <code class="filename">/home</code>,
+                                <code class="filename">/media</code>,
+                                <code class="filename">/opt</code>,
+                                <code class="filename">/run/media</code> and
+                                <code class="filename">/srv</code> if they exist.
+                            </p><p>
+                                <code class="filename">/dev</code> is not shared:
+                                use <code class="option">devices=all;</code> instead.
+                            </p><p>
+                                Parts of <code class="filename">/sys</code> are always
+                                shared. This option does not make additional
+                                files in /sys available.
+                            </p><p>
+                                These other reserved directories are
+                                currently excluded:
+                                <code class="filename">/app</code>,
+                                <code class="filename">/bin</code>,
+                                <code class="filename">/boot</code>,
+                                <code class="filename">/etc</code>,
+                                <code class="filename">/lib</code>,
+                                <code class="filename">/lib32</code>,
+                                <code class="filename">/lib64</code>,
+                                <code class="filename">/proc</code>,
+                                <code class="filename">/root</code>,
+                                <code class="filename">/run</code>,
+                                <code class="filename">/sbin</code>,
+                                <code class="filename">/tmp</code>,
+                                <code class="filename">/usr</code>,
+                                <code class="filename">/var</code>.
+                            </p><p>
+                                Available since 0.3.
+                            </p></dd><dt><span class="term"><code class="option">xdg-desktop</code>,
+                                <code class="option">xdg-documents</code>,
+                                <code class="option">xdg-download</code>,
+                                <code class="option">xdg-music</code>,
+                                <code class="option">xdg-pictures</code>,
+                                <code class="option">xdg-public-share</code>,
+                                <code class="option">xdg-videos</code>,
+                                <code class="option">xdg-templates</code>
+                            </span></dt><dd><p>
+                                <a class="ulink" href="https://www.freedesktop.org/wiki/Software/xdg-user-dirs/" target="_top">freedesktop.org special directories</a>.
+                                Available since 0.3.
+                            </p></dd><dt><span class="term"><code class="option">xdg-desktop/<em class="replaceable"><code>path</code></em></code>,
+                                <code class="option">xdg-documents/<em class="replaceable"><code>path</code></em></code>,
+                                etc.
+                            </span></dt><dd><p>
+                                Subdirectories of freedesktop.org special
+                                directories. Available since 0.4.13.
+                            </p></dd><dt><span class="term">
+                                <code class="option">xdg-cache</code>,
+                                <code class="option">xdg-config</code>,
+                                <code class="option">xdg-data</code>
+                            </span></dt><dd><p>
+                                Directories defined by the
+                                <a class="ulink" href="https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html" target="_top">freedesktop.org Base Directory
+                                  Specification</a>.
+                                Available since 0.6.14.
+                            </p></dd><dt><span class="term">
+                                <code class="option">xdg-cache/<em class="replaceable"><code>path</code></em></code>,
+                                <code class="option">xdg-config/<em class="replaceable"><code>path</code></em></code>,
+                                <code class="option">xdg-data/<em class="replaceable"><code>path</code></em></code>
+                            </span></dt><dd><p>
+                                Subdirectories of directories defined by the
+                                freedesktop.org Base Directory Specification.
+                                Available since 0.6.14.
+                            </p></dd><dt><span class="term">
+                                <code class="option">xdg-run/<em class="replaceable"><code>path</code></em></code>
+                            </span></dt><dd><p>
+                                Subdirectories of the
+                                <code class="envar">XDG_RUNTIME_DIR</code> defined by
+                                the
+                                <a class="ulink" href="https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html" target="_top">freedesktop.org Base Directory
+                                  Specification</a>. Note that
+                                <code class="option">xdg-run</code> on its own is not
+                                supported. Available since 0.4.13.
+                            </p></dd><dt><span class="term">
+                                <code class="option">/<em class="replaceable"><code>path</code></em></code>
+                            </span></dt><dd><p>
+                                An arbitrary absolute path. Available since 0.3.
+                            </p></dd><dt><span class="term">
+                                <code class="option">~/<em class="replaceable"><code>path</code></em></code>
+                            </span></dt><dd><p>
+                                An arbitrary path relative to the home
+                                directory. Available since 0.3.
+                            </p></dd><dt><span class="term">
+                                One of the above followed by
+                                <code class="option">:ro</code>
+                            </span></dt><dd><p>
+                                Make the given directory available read-only.
+                            </p></dd><dt><span class="term">
+                                One of the above followed by
+                                <code class="option">:rw</code>
+                            </span></dt><dd><p>
+                                Make the given directory available read/write.
+                                This is the default.
+                            </p></dd><dt><span class="term">
+                                One of the above followed by
+                                <code class="option">:create</code>
+                            </span></dt><dd><p>
+                                Make the given directory available read/write,
+                                and create it if it does not already exist.
+                            </p></dd></dl></div><p>
                     </p></dd><dt><span class="term"><code class="option">persistent</code> (list)</span></dt><dd><p>
                       List of homedir-relative paths to make available at
                       the corresponding path in the per-application home directory,
@@ -2060,8 +2250,56 @@ Content Bytes Written: 305
                       For instance making ".myapp" persistent would make "~/.myapp"
                       in the sandbox a bind mount to "~/.var/app/org.my.App/.myapp",
                       thus allowing an unmodified application to save data in
-                      the per-application location.
-                    </p></dd></dl></div></div><div class="refsect2"><a id="idm139821834455888"></a><h3>[Session Bus Policy]</h3><p>
+                      the per-application location. Available since 0.3.
+                    </p></dd><dt><span class="term"><code class="option">features</code> (list)</span></dt><dd><p>
+                        List of features available or unavailable to the
+                        application, currently from the following list:
+                        </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">devel</code></span></dt><dd><p>
+                                Allow system calls used by development-oriented
+                                tools such as <span class="command"><strong>perf</strong></span>,
+                                <span class="command"><strong>strace</strong></span> and
+                                <span class="command"><strong>gdb</strong></span>.
+                                Available since 0.6.10.
+                            </p></dd><dt><span class="term"><code class="option">multiarch</code></span></dt><dd><p>
+                                Allow running multilib/multiarch binaries, for
+                                example <code class="literal">i386</code> binaries in an
+                                <code class="literal">x86_64</code> environment.
+                                Available since 0.6.12.
+                            </p></dd></dl></div><p>
+                        A feature can be prefixed with <code class="option">!</code> to
+                        indicate the absence of that feature, for example
+                        <code class="option">!devel</code> if development and debugging
+                        are not allowed.
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm4793"></a><h3>[Instance]</h3><p>
+                This group only appears in <code class="filename">/.flatpak-info</code>
+                for a running app, and not in the metadata files written by
+                application authors. It is filled in by Flatpak itself.
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">app-path</code> (string)</span></dt><dd><p>
+                        The absolute path on the host system of the app's
+                        app files, as mounted at <code class="filename">/app</code>
+                        inside the container. Available since 0.6.10.
+                    </p></dd><dt><span class="term"><code class="option">branch</code> (string)</span></dt><dd><p>
+                        The branch of the app, for example
+                        <code class="literal">stable</code>. Available since
+                        0.6.10.
+                    </p></dd><dt><span class="term"><code class="option">flatpak-version</code> (string)</span></dt><dd><p>
+                        The version number of the Flatpak version that ran
+                        this app. Available since 0.6.11.
+                    </p></dd><dt><span class="term"><code class="option">runtime-path</code> (string)</span></dt><dd><p>
+                        The absolute path on the host system of the app's
+                        runtime files, as mounted at <code class="filename">/usr</code>
+                        inside the container. Available since 0.6.10.
+                    </p></dd><dt><span class="term"><code class="option">session-bus-proxy</code> (boolean)</span></dt><dd><p>
+                        True if this app cannot access the D-Bus session bus
+                        directly (either it goes via a proxy, or it cannot
+                        access the session bus at all). Available since 0.8.0.
+                        
+                    </p></dd><dt><span class="term"><code class="option">system-bus-proxy</code> (boolean)</span></dt><dd><p>
+                        True if this app cannot access the D-Bus system bus
+                        directly (either it goes via a proxy, or it cannot
+                        access the system bus at all). Available since 0.8.0.
+                        
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm4831"></a><h3>[Session Bus Policy]</h3><p>
                 If the <code class="option">sockets</code> key is not allowing full access
                 to the D-Bus session bus, then flatpak provides filtered access.
             </p><p>
@@ -2089,87 +2327,109 @@ Content Bytes Written: 305
                 access:
             </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">none</code></span></dt><dd><p>
                         The bus name or names in question is invisible to the application.
+                        Available since 0.2.
                     </p></dd><dt><span class="term"><code class="option">see</code></span></dt><dd><p>
                         The bus name or names can be enumerated by the application.
+                        Available since 0.2.
                     </p></dd><dt><span class="term"><code class="option">talk</code></span></dt><dd><p>
                         The application can send messages/ and receive replies and signals from the bus name or names.
+                        Available since 0.2.
                     </p></dd><dt><span class="term"><code class="option">own</code></span></dt><dd><p>
                         The application can own the bus name or names (as well as all the above).
-                    </p></dd></dl></div></div><div class="refsect2"><a id="idm139821834442496"></a><h3>[System Bus Policy]</h3><p>
+                        Available since 0.2.
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm4863"></a><h3>[System Bus Policy]</h3><p>
                 If the <code class="option">sockets</code> key is not allowing full access
                 to the D-Bus system bus, then flatpak does not make the system
                 bus available unless the [System Bus Policy] group is present
-                and provides a policy for filtered access.
+                and provides a policy for filtered access. Available since 0.2.
             </p><p>
                 Entries in this group have the same form as for the [Session Bus Policy] group.
                 However, the app has no permissions by default.
-            </p></div><div class="refsect2"><a id="idm139821834439840"></a><h3>[Environment]</h3><p>
+            </p></div><div class="refsect2"><a id="idm4868"></a><h3>[Environment]</h3><p>
                 The [Environment] group specifies environment variables to set
-                when running the application.
+                when running the application. Available since 0.3.
             </p><p>
                 Entries in this group have the form <code class="option">VAR=VALUE</code>
                 where <code class="option">VAR</code> is the name of an environment variable
                 to set.
-            </p></div><div class="refsect2"><a id="idm139821834055920"></a><h3>[Extension NAME]</h3><p>
-                Runtimes and applications can define extensions, which are optional,
-                additional runtimes to be mounted at a specified location inside
-                the sandbox when they are present on the system. Typical uses for
-                extensions include translations for applications, or debuginfo
-                for sdks. The name of the extension is specified as part of the
+            </p></div><div class="refsect2"><a id="idm4874"></a><h3>[Extension NAME]</h3><p>
+                Runtimes and applications can define extension points, which allow
+                optional, additional runtimes to be mounted at a specified location
+                inside the sandbox when they are present on the system. Typical uses
+                for extension points include translations for applications, or debuginfo
+                for sdks. The name of the extension point is specified as part of the
                 group heading.
             </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">directory</code> (string)</span></dt><dd><p>
                         The relative path at which the extension will be mounted in
-                        the sandbox. If the extension is for an application, the
+                        the sandbox. If the extension point is for an application, the
                         path is relative to <code class="filename">/app</code>, otherwise
                         it is relative to <code class="filename">/usr</code>. This key
-                        is mandatory.
+                        is mandatory. Available since 0.1.
                     </p></dd><dt><span class="term"><code class="option">version</code> (string)</span></dt><dd><p>
                         The branch to use when looking for the extension. If this is
                         not specified, it defaults to the branch of the application or
-                        runtime that the extension is for.
+                        runtime that the extension point is for.
+                        Available since 0.4.1.
                     </p></dd><dt><span class="term"><code class="option">versions</code> (string)</span></dt><dd><p>
                         The branches to use when looking for the extension. If this is
                         not specified, it defaults to the branch of the application or
-                        runtime that the extension is for.
+                        runtime that the extension point is for. Available since
+                        0.9.1, and backported to the 0.8.x branch in 0.8.4.
                     </p></dd><dt><span class="term"><code class="option">add-ld-path</code> (string)</span></dt><dd><p>
-                        A path relative to the extension directory that will be appended
-                        to LD_LIBRARY_PATH.
+                        A path relative to the extension point directory that will be appended
+                        to LD_LIBRARY_PATH. Available since 0.9.1, and
+                        backported to the 0.8.x branch in 0.8.3.
                     </p></dd><dt><span class="term"><code class="option">merge-dirs</code> (string)</span></dt><dd><p>
-                        A list of relative paths of directories below the extension directory
-                        that will be merged.
+                        A list of relative paths of directories below the extension point directory
+                        that will be merged. Available since 0.9.1, and
+                        backported to the 0.8.x branch in 0.8.3.
                     </p></dd><dt><span class="term"><code class="option">download-if</code> (string)</span></dt><dd><p>
                         A condition that must be true for the extension to be auto-downloaded.
                         The only currently recognized value is active-gl-driver, which is true
-                        if the name of the active GL driver matches the extension basename.
+                        if the name of the active GL driver matches the extension point basename.
+                        Available since 0.9.1, and backported to the 0.8.x
+                        branch in 0.8.3.
                     </p></dd><dt><span class="term"><code class="option">enable-if</code> (string)</span></dt><dd><p>
                         A condition that must be true for the extension to be enabled.
                         The only currently recognized value is active-gl-driver, which is true
-                        if the name of the active GL driver matches the extension basename.
+                        if the name of the active GL driver matches the extension point basename.
+                        Available since 0.9.1, and backported to the 0.8.x
+                        branch in 0.8.3.
                     </p></dd><dt><span class="term"><code class="option">subdirectory-suffix</code> (string)</span></dt><dd><p>
                         A suffix that gets appended to the directory name. This is very
                         useful when the extension point naming scheme is "reversed". For example,
                         an extension point for GTK+ themes would be /usr/share/themes/$NAME/gtk-3.0,
                         which could be achieved using subdirectory-suffix=gtk-3.0.
+                        Available since 0.9.1, and backported to the 0.8.x
+                        branch in 0.8.3.
                     </p></dd><dt><span class="term"><code class="option">subdirectories</code> (boolean)</span></dt><dd><p>
                         If this key is set to true, then flatpak will look for
-                        extensions whose name is a prefix of the extension name, and
+                        extensions whose name is a prefix of the extension point name, and
                         mount them at the corresponding name below the subdirectory.
+                        Available since 0.1.
                     </p></dd><dt><span class="term"><code class="option">no-autodownload</code> (boolean)</span></dt><dd><p>
-                        Whether to automatically download this extension
-                        when updating or installing a 'related' application
-                        or runtime.
+                        Whether to automatically download extensions matching this extension
+                        point when updating or installing a 'related' application or runtime.
+                        Available since 0.6.7.
+                    </p></dd><dt><span class="term"><code class="option">locale-subset</code> (boolean)</span></dt><dd><p>
+                        If set, then the extensions are partially downloaded by default,
+                        based on the currently configured locales. This means that the extension
+                        contents should be a set of directories with the language code as name.
+                        Available since 0.9.13 (and 0.6.6 for any extensions called *.Locale)
                     </p></dd><dt><span class="term"><code class="option">autodelete</code> (boolean)</span></dt><dd><p>
-                        Whether to automatically delete this extension
-                        when deleting a 'related' application or runtime.
-                    </p></dd></dl></div></div><div class="refsect2"><a id="idm139821834030592"></a><h3>[ExtensionOf]</h3><p>
+                        Whether to automatically delete extensions matching this extension
+                        point when deleting a 'related' application or runtime.
+                        Available since 0.6.7.
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm4940"></a><h3>[ExtensionOf]</h3><p>
                 This optional group may be present if the runtime is an extension.
             </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">ref</code> (string)</span></dt><dd><p>
                         The ref of the runtime or application that this extension
-                        belongs to.
+                        belongs to. Available since 0.9.1.
                     </p></dd><dt><span class="term"><code class="option">priority</code> (integer)</span></dt><dd><p>
                         The priority to give this extension when looking for the
-                        best match. Default is 0.
-                    </p></dd></dl></div></div><div class="refsect2"><a id="idm139821834024928"></a><h3>[Extra Data]</h3><p>
+                        best match. Default is 0. Available since 0.9.1, and
+                        backported to the 0.8.x branch in 0.8.3.
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm4954"></a><h3>[Extra Data]</h3><p>
                 This optional group may be present if the runtime or application uses
                 extra data that gets downloaded separately. The data in this group
                 gets merged into the repository summary, with the xa.extra-data-sources
@@ -2181,14 +2441,26 @@ Content Bytes Written: 305
             </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">NoRuntime</code> (boolean)</span></dt><dd><p>
                         Whether to mount the runtime while running the /app/bin/apply_extra
                         script. Defaults to true, i.e. not mounting the runtime.
-                    </p></dd><dt><span class="term"><code class="option">uriX</code> (string)</span></dt><dd><p>
-                        The uri for extra data source X. The only supported uri schemes are
-                        http and https.
-                    </p></dd><dt><span class="term"><code class="option">sizeX</code> (integer)</span></dt><dd><p>
-                        The size for extra data source X.
-                    </p></dd><dt><span class="term"><code class="option">checksumX</code> (string)</span></dt><dd><p>
-                        The sha256 sum for extra data source X.
-                    </p></dd></dl></div></div></div><div class="refsect1"><a id="idm139821834014720"></a><h2>Example</h2><pre class="programlisting">
+                        Available since 0.9.1, and backported to the 0.8.x
+                        branch in 0.8.4.
+                    </p></dd><dt><span class="term"><code class="option">uri<em class="replaceable"><code>X</code></em></code> (string)</span></dt><dd><p>
+                        The uri for extra data source
+                        <em class="replaceable"><code>X</code></em>. The only supported uri
+                        schemes are http and https. Available since 0.6.13.
+                    </p></dd><dt><span class="term"><code class="option">size<em class="replaceable"><code>X</code></em></code> (integer)</span></dt><dd><p>
+                        The size for extra data source
+                        <em class="replaceable"><code>X</code></em>. Available since 0.6.13.
+                    </p></dd><dt><span class="term"><code class="option">checksum<em class="replaceable"><code>X</code></em></code> (string)</span></dt><dd><p>
+                        The sha256 sum for extra data source
+                        <em class="replaceable"><code>X</code></em>. Available since 0.6.13.
+                    </p></dd></dl></div></div><div class="refsect2"><a id="idm4985"></a><h3>[Policy SUBSYSTEM]</h3><p>
+            Subsystems can define their own policies to be placed in a group
+            whose name has this form. Their values are treated as lists,
+            in which items can have their meaning negated by prepending !
+            to the value. They are not otherwise parsed by Flatpak.
+            Available since 0.6.13.
+            
+          </p></div></div><div class="refsect1"><a id="idm4988"></a><h2>Example</h2><pre class="programlisting">
 [Application]
 name=org.gnome.Calculator
 runtime=org.gnome.Platform/x86_64/3.20
@@ -2212,182 +2484,11 @@ subdirectories=true
 
 [Extension org.gnome.Calculator.Debug]
 directory=lib/debug
-</pre></div><div class="refsect1"><a id="idm139821834012640"></a><h2>See also</h2><p>
+</pre></div><div class="refsect1"><a id="idm4991"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-run"><span class="citerefentry"><span class="refentrytitle">flatpak-run</span>(1)</span></a>,
             <a class="citerefentry" href="#flatpak-override"><span class="citerefentry"><span class="refentrytitle">flatpak-override</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-flatpakrepo"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-flatpakrepo — Reference to a remote</p></div><div class="refsect1"><a id="idm139821839558992"></a><h2>Description</h2><p>
-            Flatpak uses flatpakrepo files to share information about remotes.
-            The <code class="filename">flatpakrepo</code> file contains enough information
-            to add the remote. Use the <span class="command"><strong>flatpak remote-add --from</strong></span>
-            command to do so.
-        </p><p>
-           The filename extension commonly used for flatpakrepo files is <code class="filename">.flatpakrepo</code>.
-        </p></div><div class="refsect1"><a id="idm139821839240576"></a><h2>File format</h2><p>
-            The flatpakrepo file is using the same .ini file format that is used for
-            systemd unit files or application .desktop files.
-        </p><div class="refsect2"><a id="idm139821834784208"></a><h3>[Flatpak Repo]</h3><p>
-                All the information is contained in the [Flatpak Repo] group.
-            </p><p>
-                The following keys can be present in this group:
-            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Url</code> (string)</span></dt><dd><p>The url for the remote. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Title</code> (string)</span></dt><dd><p>The title of the remote. This should be a user-friendly name that can be displayed e.g. in an app store.</p></dd><dt><span class="term"><code class="option">GPGKey</code> (string)</span></dt><dd><p>The base64-encoded gpg key for the remote.</p></dd><dt><span class="term"><code class="option">DefaultBranch</code> (string)</span></dt><dd><p>The default branch to use for this remote.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm139821834418752"></a><h2>Example</h2><pre class="programlisting">
-[Flatpak Repo]
-Title=GEdit
-Url=http://sdk.gnome.org/repo-apps/
-GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
-</pre></div><div class="refsect1"><a id="idm139821834342560"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-remote-add"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-add</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-flatpakref"><span class="citerefentry"><span class="refentrytitle">flatpak-flatpakref</span>(5)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-flatpakref"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-flatpakref — Reference to a remote for an application or runtime</p></div><div class="refsect1"><a id="idm139821839226080"></a><h2>Description</h2><p>
-            Flatpak uses flatpakref files to share information about a remote for
-            a single application. The <code class="filename">flatpakref</code> file contains
-            enough information to add the remote and install the application.
-            Use the <span class="command"><strong>flatpak install --from</strong></span> command to do so.
-        </p><p>
-           The filename extension commonly used for flatpakref files is <code class="filename">.flatpakref</code>.
-        </p><p>
-           A flatpakref file can also refer to a remote for a runtime.
-        </p></div><div class="refsect1"><a id="idm139821836836256"></a><h2>File format</h2><p>
-            The flatpakref file is using the same .ini file format that is used for
-            systemd unit files or application .desktop files.
-        </p><div class="refsect2"><a id="idm139821839537920"></a><h3>[Flatpak Ref]</h3><p>
-                All the information is contained in the [Flatpak Ref] group.
-            </p><p>
-                The following keys can be present in this group:
-            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Name</code> (string)</span></dt><dd><p>The fully qualified name of the runtime that is used by the application. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Url</code> (string)</span></dt><dd><p>The url for the remote. This key is mandatory.</p></dd><dt><span class="term"><code class="option">Branch</code> (string)</span></dt><dd><p>The name of the branch from which to install the application or runtime. If this key is not specified, the "master" branch is used.</p></dd><dt><span class="term"><code class="option">Title</code> (string)</span></dt><dd><p>The title of the application or runtime. This should be a user-friendly name that can be displayed e.g. in an app store.</p></dd><dt><span class="term"><code class="option">IsRuntime</code> (boolean)</span></dt><dd><p>Whether this file refers to a runtime. If this key is not specified, the file is assumed to refer to an application.</p></dd><dt><span class="term"><code class="option">GPGKey</code> (string)</span></dt><dd><p>The base64-encoded gpg key for the remote.</p></dd><dt><span class="term"><code class="option">RuntimeRepo</code> (string)</span></dt><dd><p>The url for a .flatpakref file for the runtime.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm139821834316304"></a><h2>Example</h2><pre class="programlisting">
-[Flatpak Ref]
-Title=GEdit
-Name=org.gnome.gedit
-Branch=stable
-Url=http://sdk.gnome.org/repo-apps/
-IsRuntime=False
-GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=
-</pre></div><div class="refsect1"><a id="idm139821834338464"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak"><span class="citerefentry"><span class="refentrytitle">flatpak</span>(1)</span></a>,
-            <a class="citerefentry" href="#flatpak-install"><span class="citerefentry"><span class="refentrytitle">flatpak-install</span>(1)</span></a>
-            <a class="citerefentry" href="#flatpak-flatpakrepo"><span class="citerefentry"><span class="refentrytitle">flatpak-flatpakrepo</span>(5)</span></a>,
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-manifest"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-manifest — Information for building an application</p></div><div class="refsect1"><a id="idm139821836002368"></a><h2>Description</h2><p>
-          Flatpak uses manifest, or recipe, files in a json format to describe how an
-          application and its bundled dependencies can be built from sources. The manifest
-          gets used by flatpak-builder.
-       </p></div><div class="refsect1"><a id="idm139821838653712"></a><h2>File format</h2><p>
-          The top level of the json file describes global attributes of the application, how
-          it can be built, and the list of modules that need to be built.
-        </p><div class="refsect2"><a id="idm139821834871184"></a><h3>Toplevel properties</h3><p>
-          These are the properties that are accepted:
-        </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">id</code> or <code class="option">app-id</code> (string)</span></dt><dd><p>A string defining the application id.</p></dd><dt><span class="term"><code class="option">branch</code> (string)</span></dt><dd><p>The branch of the application, defaults to master.</p></dd><dt><span class="term"><code class="option">runtime</code> (string)</span></dt><dd><p>The name of the runtime that the application uses.</p></dd><dt><span class="term"><code class="option">runtime-version</code> (string)</span></dt><dd><p>The version of the runtime that the application uses, defaults to master.</p></dd><dt><span class="term"><code class="option">sdk</code> (string)</span></dt><dd><p>The name of the development runtime that the application builds with.</p></dd><dt><span class="term"><code class="option">var</code> (string)</span></dt><dd><p>Initialize the (otherwise empty) writable /var in the build with a copy of this runtime.</p></dd><dt><span class="term"><code class="option">metadata</code> (string)</span></dt><dd><p>Use this file as the base metadata file when finishing.</p></dd><dt><span class="term"><code class="option">command</code> (string)</span></dt><dd><p>The filename or path to the main binary of the application. Note that this is really just a single file, not a commandline. If you want to pass arguments, install a shell script wrapper and use that as the command.</p></dd><dt><span class="term"><code class="option">build-runtime</code> (boolean)</span></dt><dd><p>Build a new runtime instead of an application.</p></dd><dt><span class="term"><code class="option">build-extension</code> (boolean)</span></dt><dd><p>Build an extension.</p></dd><dt><span class="term"><code class="option">separate-locales</code> (boolean)</span></dt><dd><p>Separate out locale files and translations to an extension runtime. Defaults to true.</p></dd><dt><span class="term"><code class="option">id-platform</code> (string)</span></dt><dd><p>When building a runtime sdk, also create a platform based on it with this id.</p></dd><dt><span class="term"><code class="option">metadata-platform</code> (string)</span></dt><dd><p>The metadata file to use for the platform we create.</p></dd><dt><span class="term"><code class="option">writable-sdk</code> (boolean)</span></dt><dd><p>If true, use a writable copy of the sdk for /usr.
-                    Defaults to true if build-runtime is specified.</p></dd><dt><span class="term"><code class="option">appstream-compose</code> (boolean)</span></dt><dd><p>Run appstream-compose during cleanup phase. Defaults to true.</p></dd><dt><span class="term"><code class="option">sdk-extensions</code> (array of strings)</span></dt><dd><p>Install these extra sdk extensions in /usr.</p></dd><dt><span class="term"><code class="option">platform-extensions</code> (array of strings)</span></dt><dd><p>Install these extra sdk extensions when creating the platform.</p></dd><dt><span class="term"><code class="option">base</code> (string)</span></dt><dd><p>Start with the files from the specified application. This can be
-                    used to create applications that extend another application.</p></dd><dt><span class="term"><code class="option">base-version</code> (string)</span></dt><dd><p>Use this specific version of the application specified in base.
-                    If unspecified, this uses the value specified in branch</p></dd><dt><span class="term"><code class="option">base-extensions</code> (array of strings)</span></dt><dd><p>Install these extra extensions from the base application when initializing
-                    the application directory.</p></dd><dt><span class="term"><code class="option">tags</code> (array of strings)</span></dt><dd><p>Add these tags to the metadata file.</p></dd><dt><span class="term"><code class="option">build-options</code> (object)</span></dt><dd><p>Object specifying the build environment. See below for details.</p></dd><dt><span class="term"><code class="option">modules</code> (array of objects or string)</span></dt><dd><p>An array of objects specifying the modules to be built in order.
-                    String members in the array are interpreted as the name of a separate json file that contains a module.
-                    See below for details.</p></dd><dt><span class="term"><code class="option">cleanup</code> (array of strings)</span></dt><dd><p>An array of file patterns that should be removed at the end.
-                    Patterns starting with / are taken to be full pathnames (without the /app prefix), otherwise they just match
-                    the basename.</p></dd><dt><span class="term"><code class="option">cleanup-commands</code> (array of strings)</span></dt><dd><p>An array of commandlines that are run during the cleanup phase.</p></dd><dt><span class="term"><code class="option">cleanup-platform</code> (array of strings)</span></dt><dd><p>Extra files to clean up in the platform.</p></dd><dt><span class="term"><code class="option">cleanup-platform-commands</code> (array of strings)</span></dt><dd><p>An array of commandlines that are run during the cleanup phase of the platform.</p></dd><dt><span class="term"><code class="option">finish-args</code> (array of strings)</span></dt><dd><p>An array of arguments passed to the <span class="command"><strong>flatpak build-finish</strong></span> command.</p></dd><dt><span class="term"><code class="option">rename-desktop-file</code> (string)</span></dt><dd><p>Any desktop file with this name will be renamed to a name based on id during the cleanup phase.</p></dd><dt><span class="term"><code class="option">rename-appdata-file</code> (string)</span></dt><dd><p>Any appdata file with this name will be renamed to a name based on id during the cleanup phase.</p></dd><dt><span class="term"><code class="option">rename-icon</code> (string)</span></dt><dd><p>Any icon with this name will be renamed to a name based on id during the cleanup phase. Note that this is the icon name, not the full filenames, so it should not include a filename extension. </p></dd><dt><span class="term"><code class="option">copy-icon</code> (boolean)</span></dt><dd><p>If rename-icon is set, keep a copy of the old icon file.</p></dd><dt><span class="term"><code class="option">desktop-file-name-prefix</code> (string)</span></dt><dd><p>This string will be prefixed to the Name key in the main application desktop file.</p></dd><dt><span class="term"><code class="option">desktop-file-name-suffix</code> (string)</span></dt><dd><p>This string will be suffixed to the Name key in the main application desktop file.</p></dd></dl></div></div><div class="refsect2"><a id="idm139821833545088"></a><h3>Build Options</h3><p>
-                Build options specify the build environment of a module, and can be specified globally as
-                well as per-module. Options can also be specified on a per-architecture basis using the arch property.
-            </p><p>
-                These are the properties that are accepted:
-            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">cflags</code> (string)</span></dt><dd><p>This is set in the environment variable CFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatinated with spaces inbetween.</p></dd><dt><span class="term"><code class="option">cxxflags</code> (string)</span></dt><dd><p>This is set in the environment variable CXXFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatinated with spaces inbetween.</p></dd><dt><span class="term"><code class="option">ldflags</code> (string)</span></dt><dd><p>This is set in the environment variable LDFLAGS during the build. Multiple specifications of this (in e.g. per-arch area) are concatinated with spaces inbetween.</p></dd><dt><span class="term"><code class="option">prefix</code> (string)</span></dt><dd><p>The build prefix for the modules (defaults to <code class="filename">/app</code> for
-                    applications and <code class="filename">/usr</code> for runtimes).</p></dd><dt><span class="term"><code class="option">env</code> (object)</span></dt><dd><p>This is a dictionary defining environment variables to be set during the build.</p></dd><dt><span class="term"><code class="option">build-args</code> (array of strings)</span></dt><dd><p>This is an array containing extra options to pass to flatpak build.</p></dd><dt><span class="term"><code class="option">config-opts</code> (array of strings)</span></dt><dd><p>This is an array containing extra options to pass to configure.</p></dd><dt><span class="term"><code class="option">strip</code> (boolean)</span></dt><dd><p>If this is true (the default is false) then all ELF files will be stripped after install.</p></dd><dt><span class="term"><code class="option">no-debuginfo</code> (boolean)</span></dt><dd><p>By default (if strip is not true) flatpak-builder extracts all debug info in ELF files to a separate files
-                    and puts this in an extension. If you want to disable this, set no-debuginfo to true.</p></dd><dt><span class="term"><code class="option">arch</code> (object)</span></dt><dd><p>This is a dictionary defining for each arch a separate build options object that override the main one.</p></dd></dl></div></div><div class="refsect2"><a id="idm139821833522992"></a><h3>Module</h3><p>
-                Each module specifies a source that has to be separately built and installed. It contains
-                the build options and a list of sources to download and extract before building.
-            </p><p>
-                Modules can be nested, in order to turn related modules on and off with a single key.
-            </p><p>
-                These are the properties that are accepted:
-            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">name</code> (string)</span></dt><dd><p>The name of the module, used in e.g. build logs. The name is also used for constructing filenames and commandline arguments, therefore using spaces or '/' in this string is a bad idea.</p></dd><dt><span class="term"><code class="option">disabled</code> (boolean)</span></dt><dd><p>If true, skip this module</p></dd><dt><span class="term"><code class="option">sources</code> (array of objects)</span></dt><dd><p>An array of objects defining sources that will be downloaded and extracted in order</p></dd><dt><span class="term"><code class="option">config-opts</code> (array of strings)</span></dt><dd><p>An array of options that will be passed to configure</p></dd><dt><span class="term"><code class="option">make-args</code> (array of strings)</span></dt><dd><p>An array of arguments that will be passed to make</p></dd><dt><span class="term"><code class="option">make-install-args</code> (array of strings)</span></dt><dd><p>An array of arguments that will be passed to make install</p></dd><dt><span class="term"><code class="option">rm-configure</code> (boolean)</span></dt><dd><p>If true, remove the configure script before starting build</p></dd><dt><span class="term"><code class="option">no-autogen</code> (boolean)</span></dt><dd><p>Ignore the existence of an autogen script</p></dd><dt><span class="term"><code class="option">no-parallel-make</code> (boolean)</span></dt><dd><p>Don't call make with arguments to build in parallel</p></dd><dt><span class="term"><code class="option">no-make-install</code> (boolean)</span></dt><dd><p>Don't run the make install (or equivalent) stage</p></dd><dt><span class="term"><code class="option">no-python-timestamp-fix</code> (boolean)</span></dt><dd><p>Don't fix up the *.py[oc] header timestamps for ostree use.</p></dd><dt><span class="term"><code class="option">cmake</code> (boolean)</span></dt><dd><p>Use cmake instead of configure (deprecated: use buildsystem instead)</p></dd><dt><span class="term"><code class="option">buildsystem</code> (string)</span></dt><dd><p>Build system to use: autotools, cmake, cmake-ninja, meson, simple</p></dd><dt><span class="term"><code class="option">builddir</code> (boolean)</span></dt><dd><p>Use a build directory that is separate from the source directory</p></dd><dt><span class="term"><code class="option">subdir</code> (string)</span></dt><dd><p>Build inside this subdirectory of the extracted sources</p></dd><dt><span class="term"><code class="option">build-options</code> (object)</span></dt><dd><p>A build options object that can override global options</p></dd><dt><span class="term"><code class="option">build-commands</code> (array of strings)</span></dt><dd><p>An array of commands to run during build (between make and make install if those are used).
-                    This is primarily useful when using the "simple" buildsystem.
-                    </p></dd><dt><span class="term"><code class="option">post-install</code> (array of strings)</span></dt><dd><p>An array of shell commands that are run after the install phase. Can for example
-                    clean up the install dir, or install extra files.
-                    </p></dd><dt><span class="term"><code class="option">cleanup</code> (array of strings)</span></dt><dd><p>An array of file patterns that should be removed at the end.
-                    Patterns starting with / are taken to be full pathnames (without the /app prefix), otherwise they just match
-                    the basename. Note that any patterns will only match files installed by this module.
-                    </p></dd><dt><span class="term"><code class="option">ensure-writable</code> (array of strings)</span></dt><dd><p>The way the builder works is that files in the install directory
-                    are hard-links to the cached files, so you're not allowed to modify them in-place.
-                    If you list a file in this then the hardlink will be broken and you can modify it.
-                    This is a workaround, ideally installing files should replace files, not modify
-                    existing ones.</p></dd><dt><span class="term"><code class="option">only-arches</code> (array of strings)</span></dt><dd><p>If non-empty, only build the module on the arches listed.</p></dd><dt><span class="term"><code class="option">skip-arches</code> (array of strings)</span></dt><dd><p>Don't build on any of the arches listed.</p></dd><dt><span class="term"><code class="option">cleanup-platform</code> (array of strings)</span></dt><dd><p>Extra files to clean up in the platform.</p></dd><dt><span class="term"><code class="option">modules</code> (array of objects or strings)</span></dt><dd><p>An array of objects specifying nested modules to be built before this one.
-                    String members in the array are interpreted as names of a separate json file that contains a module.</p></dd></dl></div></div><div class="refsect2"><a id="idm139821833476928"></a><h3>Sources</h3><p>
-                These contain a pointer to the source that will be extracted into the source directory before
-                the build starts. They can be of several types, distinguished by the type property.
-            </p><div class="refsect3"><a id="idm139821833475536"></a><h4>All sources</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">only-arches</code> (array of strings)</span></dt><dd><p>If non-empty, only build the module on the arches listed.</p></dd><dt><span class="term"><code class="option">skip-arches</code> (array of strings)</span></dt><dd><p>Don't build on any of the arches listed.</p></dd><dt><span class="term"><code class="option">dest</code> (string)</span></dt><dd><p>Directory inside the source dir where this source will be extracted.</p></dd></dl></div></div><div class="refsect3"><a id="idm139821833468896"></a><h4>Archive sources (tar, zip)</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">type</code></span></dt><dd><p>"archive"</p></dd><dt><span class="term"><code class="option">path</code> (string)</span></dt><dd><p>The path of the archive</p></dd><dt><span class="term"><code class="option">url</code> (string)</span></dt><dd><p>The URL of a remote archive that will be downloaded. This overrides path if both are specified.</p></dd><dt><span class="term"><code class="option">sha256</code> (string)</span></dt><dd><p>The sha256 checksum of the file, verified after download</p></dd><dt><span class="term"><code class="option">strip-components</code> (integer)</span></dt><dd><p>The number of initial pathname components to strip during extraction. Defaults to 1.</p></dd></dl></div></div><div class="refsect3"><a id="idm139821833458640"></a><h4>Git sources</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">type</code></span></dt><dd><p>"git"</p></dd><dt><span class="term"><code class="option">path</code> (string)</span></dt><dd><p>The path to a local checkout of the git repository. Due to how git-clone works, this will be much faster than specifying a URL of file:///...</p></dd><dt><span class="term"><code class="option">url</code> (string)</span></dt><dd><p>URL of the git repository. This overrides path if both are specified.</p></dd><dt><span class="term"><code class="option">branch</code> (string)</span></dt><dd><p>The branch/tag to use from the git repository</p></dd><dt><span class="term"><code class="option">commit</code> (string)</span></dt><dd><p>The commit to use from the git repository. If branch is also specified, then it is verified that the branch/tag is at this specific commit. This is
-                        a readable way to document that you're using a particular tag, but verify that it does not change.</p></dd><dt><span class="term"><code class="option">disable-fsckobjects</code> (boolean)</span></dt><dd><p>Don't use transfer.fsckObjects=1 to mirror git repository. This may be needed for some (broken) repositories.</p></dd></dl></div></div><div class="refsect3"><a id="idm139821833446208"></a><h4>Bzr sources</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">type</code></span></dt><dd><p>"bzr"</p></dd><dt><span class="term"><code class="option">url</code> (string)</span></dt><dd><p>URL of the bzr repository</p></dd><dt><span class="term"><code class="option">revision</code> (string)</span></dt><dd><p>A specific revision to use in the branch</p></dd></dl></div></div><div class="refsect3"><a id="idm139821833439664"></a><h4>File sources</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">type</code></span></dt><dd><p>"file"</p></dd><dt><span class="term"><code class="option">path</code> (string)</span></dt><dd><p>The path of a local file that will be copied into the source dir</p></dd><dt><span class="term"><code class="option">url</code> (string)</span></dt><dd><p>The URL of a remote file that will be downloaded and copied into the source dir. This overrides path if both are specified.</p></dd><dt><span class="term"><code class="option">sha256</code> (string)</span></dt><dd><p>The sha256 checksum of the file, verified after download. This is optional for local files.</p></dd><dt><span class="term"><code class="option">dest-filename</code> (string)</span></dt><dd><p>Filename to use inside the source dir, default to the basename of path.</p></dd></dl></div></div><div class="refsect3"><a id="idm139821833429232"></a><h4>Script sources</h4><p>
-                    This is a way to create a shell (/bin/sh) script from an inline set of commands.
-                </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">type</code></span></dt><dd><p>"script"</p></dd><dt><span class="term"><code class="option">commands</code> (array of strings)</span></dt><dd><p>An array of shell commands that will be put in a shellscript file</p></dd><dt><span class="term"><code class="option">dest-filename</code> (string)</span></dt><dd><p>Filename to use inside the source dir, default to the basename of path.</p></dd></dl></div></div><div class="refsect3"><a id="idm139821833422032"></a><h4>Shell sources</h4><p>
-                    This is a way to create/modify the sources by running shell commands.
-                </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">type</code></span></dt><dd><p>"shell"</p></dd><dt><span class="term"><code class="option">commands</code> (array of strings)</span></dt><dd><p>An array of shell commands that will be run during source extraction</p></dd></dl></div></div><div class="refsect3"><a id="idm139821833416672"></a><h4>Patch sources</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">type</code></span></dt><dd><p>"patch"</p></dd><dt><span class="term"><code class="option">path</code> (string)</span></dt><dd><p>The path of a patch file that will be applied in the source dir</p></dd><dt><span class="term"><code class="option">strip-components</code> (integer)</span></dt><dd><p>The value of the -p argument to patch, defaults to 1.</p></dd><dt><span class="term"><code class="option">use-git</code> (boolean)</span></dt><dd><p>Whether to use "git apply" rather than "patch" to apply the patch, required when the patch file contains binary diffs.</p></dd><dt><span class="term"><code class="option">options</code> (array of strings)</span></dt><dd><p>Extra options to pass to the patch command.</p></dd></dl></div></div></div></div><div class="refsect1"><a id="idm139821833406128"></a><h2>Examples</h2><p>
-            <span class="command"><strong>$ flatpak-builder my-app-dir manifest.json</strong></span>
-        </p><p>
-            Example manifest file:
-        </p><pre class="programlisting">
-{
-    "id": "org.test.TestApp",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.2",
-    "sdk": "org.freedesktop.Sdk",
-    "command": "test",
-    "clean": [ "/include", "*.la" ],
-    "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
-        "env": {
-            "V": "1"
-        },
-        "arch": {
-            "x86_64": {
-                "cflags": "-O3 -g",
-            }
-        }
-    },
-    "modules": [
-        {
-            "name": "pygobject",
-            "config-opts": [ "--disable-introspection" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.xz",
-                    "sha256": "fb8a1d4f665130a125011659bd347c7339c944232163dbb9a34fd0686577adb8"
-                },
-                {
-                    "type": "patch",
-                    "path": "required-pygobject-fix.patch"
-                },
-                {
-                    "type": "file",
-                    "path": "pygobject-extra-file",
-                    "dest-filename": "extra-file"
-                }
-            ]
-        },
-        {
-            "name": "babl",
-            "build-options" : { "cxxflags": "-O2 -g -std=c++11" },
-            "cleanup": [ "/bin" ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "git://git.gnome.org/babl"
-                }
-            ]
-        },
-        {
-            "name": "testapp",
-            "sources": [
-                {
-                    "type": "bzr",
-                    "url": "lp:testapp"
-                }
-            ]
-        }
-    ]
-}
-</pre></div><div class="refsect1"><a id="idm139821833401248"></a><h2>See also</h2><p>
-            <a class="citerefentry" href="#flatpak-builder"><span class="citerefentry"><span class="refentrytitle">flatpak-builder</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote — Configuration for a remote</p></div><div class="refsect1"><a id="idm139821836448944"></a><h2>Description</h2><p>
+        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-remote"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-remote — Configuration for a remote</p></div><div class="refsect1"><a id="idm5019"></a><h2>Description</h2><p>
             Flatpak stores information about configured remotes for an installation location in
             <code class="filename">$installation/repo/config</code>. For example, the remotes for the
             default system-wide installation are in
@@ -2399,43 +2500,23 @@ GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpq
        </p><p>
             System-wide remotes can be statically preconfigured by dropping
             config fragments into <code class="filename">/etc/flatpak/remotes.d/</code>.
-       </p></div><div class="refsect1"><a id="idm139821838651728"></a><h2>File format</h2><p>
+       </p></div><div class="refsect1"><a id="idm5028"></a><h2>File format</h2><p>
             The remote config file format is using the same .ini file format that is used for systemd
             unit files or application .desktop files.
-        </p><div class="refsect2"><a id="idm139821836966368"></a><h3>[remote …]</h3><p>
+        </p><div class="refsect2"><a id="idm5031"></a><h3>[remote …]</h3><p>
                 All the configuration for the the remote with name NAME is contained in the
                 [remote "NAME"] group.
             </p><p>
                 The following keys are recognized by OSTree, among others:
             </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">url</code> (string)</span></dt><dd><p>The url for the remote.</p></dd><dt><span class="term"><code class="option">gpg-verify</code> (boolean)</span></dt><dd><p>Whether to use GPG verification for content from this remote.</p></dd><dt><span class="term"><code class="option">gpg-verify-summary</code> (boolean)</span></dt><dd><p>Whether to use GPG verification for the summary of this remote.</p></dd></dl></div><p>
                 All flatpak-specific keys have a xa. prefix:
-            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">xa.disable</code> (boolean)</span></dt><dd><p>Whether the remote is disabled. Defaults to false.</p></dd><dt><span class="term"><code class="option">xa.prio</code> (integer)</span></dt><dd><p>The priority for the remote. This is used when listing remotes. Defaults to 1.</p></dd><dt><span class="term"><code class="option">xa.noenumerate</code> (boolean)</span></dt><dd><p>Whether this remote should be used when presenting available contents. Defaults to true.</p></dd><dt><span class="term"><code class="option">xa.nodeps</code> (boolean)</span></dt><dd><p>Whether this remote should be used when searching for dependencies. Defaults to true.</p></dd><dt><span class="term"><code class="option">xa.title</code> (string)</span></dt><dd><p>An optional title to use when presenting this remote in a UI.</p></dd><dt><span class="term"><code class="option">xa.default-branch</code> (string)</span></dt><dd><p>The default branch to use when installing from this remote.</p></dd><dt><span class="term"><code class="option">xa.default-branch</code> (string)</span></dt><dd><p>The default branch to use when installing from this remote.</p></dd><dt><span class="term"><code class="option">xa.main-ref</code> (string)</span></dt><dd><p>The main reference served by this remote. This is used for origin remotes of applications installed via a flatpakref file.</p></dd><dt><span class="term"><code class="option">xa.oci</code> (boolean)</span></dt><dd><p>Whether this is an OCI remote. Defaults to false.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm139821833822336"></a><h2>Examples</h2><pre class="programlisting">
+            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">xa.disable</code> (boolean)</span></dt><dd><p>Whether the remote is disabled. Defaults to false.</p></dd><dt><span class="term"><code class="option">xa.prio</code> (integer)</span></dt><dd><p>The priority for the remote. This is used when listing remotes. Defaults to 1.</p></dd><dt><span class="term"><code class="option">xa.noenumerate</code> (boolean)</span></dt><dd><p>Whether this remote should be used when presenting available contents. Defaults to true.</p></dd><dt><span class="term"><code class="option">xa.nodeps</code> (boolean)</span></dt><dd><p>Whether this remote should be used when searching for dependencies. Defaults to true.</p></dd><dt><span class="term"><code class="option">xa.title</code> (string)</span></dt><dd><p>An optional title to use when presenting this remote in a UI.</p></dd><dt><span class="term"><code class="option">xa.title-is-set</code> (boolean)</span></dt><dd><p>This key is set to true if <code class="option">xa.title</code> has been explicitly set.</p></dd><dt><span class="term"><code class="option">xa.default-branch</code> (string)</span></dt><dd><p>The default branch to use when installing from this remote.</p></dd><dt><span class="term"><code class="option">xa.default-branch-is-set</code> (boolean)</span></dt><dd><p>This key is set to true if <code class="option">xa.default-branch</code> has been explicitly set.</p></dd><dt><span class="term"><code class="option">xa.main-ref</code> (string)</span></dt><dd><p>The main reference served by this remote. This is used for origin remotes of applications installed via a flatpakref file.</p></dd><dt><span class="term"><code class="option">xa.oci</code> (boolean)</span></dt><dd><p>Whether this is an OCI remote. Defaults to false.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm5105"></a><h2>Examples</h2><pre class="programlisting">
 [remote "gnome-nightly-apps"]
 gpg-verify=true
 gpg-verify-summary=true
+
 url=https://sdk.gnome.org/nightly/repo-apps/
 xa.title=GNOME Applications
-</pre></div><div class="refsect1"><a id="idm139821833820592"></a><h2>See also</h2><p>
+</pre></div><div class="refsect1"><a id="idm5108"></a><h2>See also</h2><p>
             <a class="citerefentry" href="#flatpak-remote-modify"><span class="citerefentry"><span class="refentrytitle">flatpak-remote-modify</span>(1)</span></a>
-        </p></div></div><div class="refentry"><div class="refentry.separator"><hr /></div><a id="flatpak-installation"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>flatpak-installation — Configuration for an installation location</p></div><div class="refsect1"><a id="idm139821839737968"></a><h2>Description</h2><p>
-            flatpak can operate in system-wide or per-user mode. The system-wide data
-            is located in <code class="filename">$prefix/var/lib/flatpak/</code>, and the per-user data is in
-            <code class="filename">$HOME/.local/share/flatpak/</code>.
-        </p><p>
-            In addition to the default installation locations, more system-wide installations
-            can be defined via configuration files <code class="filename">/etc/flatpak/installations.d/</code>,
-            which must have the .conf extension and follow the format described below.
-        </p></div><div class="refsect1"><a id="idm139821838920384"></a><h2>File format</h2><p>
-            The installation config file format is using the same .ini file format that is used
-            for systemd unit files or application .desktop files.
-        </p><div class="refsect2"><a id="idm139821836863968"></a><h3>[Installation …]</h3><p>
-                All the configuration for the the installation location with name NAME is contained
-                in the [Installation "NAME"] group.
-            </p><p>
-                The following keys are recognized:
-            </p><div class="variablelist"><dl class="variablelist"><dt><span class="term"><code class="option">Path</code> (string)</span></dt><dd><p>The path for this installation. This key is mandatory.</p></dd><dt><span class="term"><code class="option">DisplayName</code> (string)</span></dt><dd><p>The name to use when showing this installation in the UI.</p></dd><dt><span class="term"><code class="option">Priority</code> (integer)</span></dt><dd><p>A priority for this installation.</p></dd><dt><span class="term"><code class="option">StorageType</code> (string)</span></dt><dd><p>The type of storage used for this installation. Possible values include: mmc, sdcard, harddisk.</p></dd></dl></div></div></div><div class="refsect1"><a id="idm139821833294112"></a><h2>Examples</h2><pre class="programlisting">
-[Installation "extra"]
-Path=/location/of/sdcard
-DisplayName=Extra Installation
-StorageType=sdcard
-</pre></div></div></div></div></body></html>
+        </p></div></div></div></div></body></html>


### PR DESCRIPTION
This copies the flatpak-docs.html file generated in the doc folder of
flatpak.git