### PR TITLE
add a page on available runtimes

### DIFF
--- a/docs/available-runtimes.rst
+++ b/docs/available-runtimes.rst
@@ -28,14 +28,10 @@ GNOME
 
 The GNOME runtime is appropriate for any application that uses the GNOME platform. It is based on the Freedesktop runtime and adds the GNOME platform, including:
 
-* AT-SPI
-* ATK (Accessibility Toolkit)
 * Clutter
-* dconf
 * Gjs
 * GObject Introspection
 * GStreamer
-* GTK+
 * GVFS
 * Libnotify
 * Libsecret

--- a/docs/available-runtimes.rst
+++ b/docs/available-runtimes.rst
@@ -1,0 +1,76 @@
+Available Runtimes
+==================
+
+This page provides information about available Flatpak runtimes. It is primarily intended as information for application developers and distributors.
+
+There are currently three main runtimes available: Freedesktop, GNOME and KDE. These are all hosted on `Flathub <https://flathub.org/>`_.
+
+Freedesktop
+-----------
+
+The Freedesktop runtime is the standard runtime that can be used for any application and contains a set of essential libraries and services, including D-Bus, GLib, PulseAudio, X11 and Wayland.
+
+Available Freedesktop runtimes:
+
+===============================  =================================
+ID                               Description
+===============================  =================================
+org.freedesktop.Platform         Runtime
+org.freedesktop.Platform.Locale  Runtime translations (extension)
+org.freedesktop.Sdk              SDK
+org.freedesktop.Sdk.Debug        SDK debug information (extension)
+org.freedesktop.Sdk.Locale       SDK translations (extension)
+org.freedesktop.Sdk.Docs         SDK documentation (extension)
+===============================  =================================
+
+GNOME
+-----
+
+The GNOME runtime is appropriate for any application that uses the GNOME platform. It is based on the Freedesktop runtime and adds the GNOME platform, including:
+
+* AT-SPI
+* ATK (Accessibility Toolkit)
+* Clutter
+* dconf
+* Gjs
+* GObject Introspection
+* GStreamer
+* GTK+
+* GVFS
+* Libnotify
+* Libsecret
+* LibSoup
+* PyGObject
+* Vala
+* WebKitGTK
+
+Available GNOME runtimes:
+
+=========================  =================================
+ID                         Description
+=========================  =================================
+org.gnome.Platform         Runtime
+org.gnome.Platform.Locale  Runtime translations (extension)
+org.gnome.Sdk              SDK
+org.gnome.Sdk.Debug        SDK debug information (extension)
+org.gnome.Sdk.Locale       SDK translations (extension)
+org.gnome.Sdk.Docs         SDK documentation (extension)
+=========================  =================================
+
+KDE
+===
+
+The KDE runtime is also based on the Freedesktop runtime and adds Qt and KDE Frameworks. It is appropriate for any application that makes use of the KDE platform and most Qt-based applications.
+
+Available KDE runtimes:
+
+=======================  =================================
+ID                       Description
+=======================  =================================
+org.kde.Platform         Runtime
+org.kde.Platform.Locale  Runtime translations (extension)
+org.kde.Sdk              SDK
+org.kde.Sdk.Debug        SDK debug information (extension)
+org.kde.Sdk.Locale       SDK translations (extension)
+org.kde.Sdk.Docs         SDK documentation (extension)
+=======================  =================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,5 +21,6 @@ Contents
    flatpak-builder
    working-with-the-sandbox
    distributing-applications
+   available-runtimes
    command-reference
    flatpak-builder-command-reference


### PR DESCRIPTION
This is a port of the page that is currently hosted on
flatpak.org. It is logical to keep all the information for
developers together, as part of the docs.