### PR TITLE
Update examples to use recent versions

### DIFF
--- a/docs/flatpak-builder.rst
+++ b/docs/flatpak-builder.rst
@@ -17,7 +17,7 @@ The GNOME Dictionary manifest is short, because the only module is the applicati
   {
     "app-id": "org.gnome.Dictionary",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.22",
+    "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-dictionary",
     "finish-args": [
@@ -30,8 +30,8 @@ The GNOME Dictionary manifest is short, because the only module is the applicati
         "sources": [
           {
             "type": "archive",
-            "url": "https://download.gnome.org/sources/gnome-dictionary/3.20/gnome-dictionary-3.20.0.tar.xz",
-            "sha256": "efb36377d46eff9291d3b8fec37baab2355f9dc8bc7edb791b6a625574716121"
+            "url": "https://download.gnome.org/sources/gnome-dictionary/3.26/gnome-dictionary-3.26.0.tar.xz",
+            "sha256": "387ff8fbb8091448453fd26dcf0b10053601c662e59581097bc0b54ced52e9ef"
           }
         ]
       }

--- a/docs/getting-setup.rst
+++ b/docs/getting-setup.rst
@@ -1,34 +1,35 @@
 Getting Setup
 =============
 
-Getting setup to build Flatpaks is quick and easy. First, it is necessary to have the ``flatpak`` and ``flatpak-builder`` packages installed on your system. These are available for most distributions, and the Flatpak website provides `details on how to get them <http://flatpak.org/getting.html>`_.
+Install flatpak and flatpak-builder
+-----------------------------------
 
-Once flatpak has been installed, it is necessary to pick a runtime and install it, along with the matching SDK.
+First, it is necessary to have the ``flatpak`` and ``flatpak-builder`` packages installed on your system. The Flatpak website provides `details on how to install flatpak <http://flatpak.org/getting.html>`_. ``flatpak-builder`` is typically found as a package from the same source as ``flatpak`` itself.
 
-Installing an SDK
------------------
+Add the flathub repository
+--------------------------
 
-An SDK is a special type of runtime that is used to build applications. Typically, an SDK is paired with a runtime that will be used by the application at runtime. For example the GNOME 3.22 SDK is used to build applications that use the GNOME 3.22 runtime.
+Flathub is the main Flatpak repository and contains the runtimes and SDKs that will be needed to run and build apps. If you haven't added it already, it can be setup with the following command::
 
-The Flatpak website provides a `list of the available runtimes <http://flatpak.org/runtimes.html>`_. Once you have decided which one to use, getting setup is just a matter of installing it and its SDK.
+  $ flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-The examples in the rest of the Flatpak documentation use the GNOME 3.22 runtime and SDK. If you haven't installed these already, download the repository GPG key and then add the repository that contains the runtime and SDK::
+Install an SDK
+--------------
 
-  $ flatpak remote-add --from gnome https://sdk.gnome.org/gnome.flatpakrepo
+An SDK is a special type of runtime that is used to build applications. Typically, an SDK is paired with a runtime that will be used by the application at runtime. For example the GNOME 3.26 SDK is used to build applications that use the GNOME 3.26 runtime.
 
-You can now download and install the runtime and SDK::
+Many of the examples in the rest of the Flatpak documentation use the GNOME 3.26 runtime and SDK. To install them, run::
 
-  $ flatpak install gnome org.gnome.Platform//3.22 org.gnome.Sdk//3.22
+  $ flatpak install flathub org.gnome.Platform//3.26 org.gnome.Sdk//3.26
 
 This same procedure can be used to install any other runtime and SDK.
 
 Taking a look around
 --------------------
 
-If this is the first time you've used Flatpak, it is a good time to try installing an application and having a look 'under the hood'. To do this, you need to add a repository that contains applications. We can do this using the gnome-apps repository to install gedit::
+If this is the first time you've used Flatpak, it is a good time to try installing an application and having a look 'under the hood'. To do this, try installing gedit::
 
-  $ flatpak remote-add --from gnome-apps https://sdk.gnome.org/gnome-apps.flatpakrepo
-  $ flatpak install gnome-apps org.gnome.gedit
+  $ flatpak install flathub org.gnome.gedit
 
 You can now use the following command to get a shell in the 'devel sandbox'::
 


### PR DESCRIPTION
The examples were using the gnome-apps remote and the GNOME 3.22
runtime and SDK. Update these to use flathub and GNOME 3.26.