### PR TITLE
Mention that single file bundles can be installed

### DIFF
--- a/docs/single-file-bundles.rst
+++ b/docs/single-file-bundles.rst
@@ -15,3 +15,7 @@ For example, to create a bundle named `dictionary.flatpak` containing the GNOME 
 To import the bundle into a repository on another machine, run::
 
   $ flatpak build-import-bundle ~/my-apps dictionary.flatpak
+
+Alternatively, bundles can also be installed directly without importing them::
+
+  $ flatpak install dictionary.flatpak


### PR DESCRIPTION
Mentioning only that bundles can be imported into repositories makes users 
assume that's a necessary step in order to install the bundle, which may not
be a desirable step for end users who only wish to install the application.