### PR TITLE
Provide guidance on sandbox permissions

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -11,3 +11,4 @@ If you haven't already, it is recommended to run through :doc:`first-build` befo
    building-basics
    flatpak-builder
    manifests
+   sandbox-permissions

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -52,19 +52,9 @@ Portals
 
 Portals are a mechanism through which applications can interact with the host environment from within a sandbox. They give the ability to interact with data, files and services without the need to add sandbox permissions.
 
-Examples of capabilities that can be accessed through portals include:
+Examples of capabilities that can be accessed through portals include opening files through a file chooser dialog, or printing. Interface toolkits can implement transparent support for portals, so access to resources outside of the sandbox will work securely and out of the box.
 
-* Opening files with a native file chooser dialog
-* Opening URIs
-* Printing
-* Showing notifications
-* Taking screenshots
-* Inhibiting the user session from ending, suspending, idling or getting switched away
-* Getting network status information
-
-Interface toolkits can implement transparent support for portals. If an application uses one of these toolkits, there is no additional work required to access them.
-
-Applications that aren't using a toolkit with support for portals can refer to the `xdg-desktop-portal API documentation <https://flatpak.github.io/xdg-desktop-portal/portal-docs.html>`_ for information on how to access them.
+More information about portals can be found in :doc:`sandbox-permissions`.
 
 Repositories
 ^^^^^^^^^^^^

--- a/docs/manifests.rst
+++ b/docs/manifests.rst
@@ -7,7 +7,7 @@ This page provides information and guidance on how to use manifests, including a
 
 Manifest files should be named using the application ID. For example, the manifest file for GNOME Dictionary is named ``org.gnome.Dictionary.json``. This page uses this manifest file, which was introduced in :doc:`first-build`, for all its examples.
 
-A complete list of all the properties that can be specified in manifest files can be found in the :doc:`flatpak-builder-command-reference`, as well as the ``flatpak-builder`` man page.
+A complete list of all the properties that can be specified in manifest files can be found in the :doc:`flatpak-builder-command-reference#flatpak-manifest`, as well as the ``flatpak-builder`` man page.
 
 Basic properties
 ----------------
@@ -55,11 +55,7 @@ The finishing manifest section uses the ``finish-args`` property, which can be s
        "--share=network"
     ],
 
-As was explained in :doc:`first-build`, these two finishing properties give the application access to the X11 display server and to the network.
-
-While there are no restrictions on which sandbox permissions an application can use, as good practice, it is recommended to use the minimum number of as permissions possible. Certain permissions, such as blanket access to the system bus (using the ``--socket=system-bus`` option) are strongly discouraged.
-
-A list of ``finish-args`` options can be found in :doc:`sandbox-permissions`.
+As was explained in :doc:`first-build`, these two finishing properties give the application access to the X11 display server and to the network. Guidance on which permissions to use can be found in :doc:`sandbox-permissions`, and a full list of ``finish-args`` options can be found in :doc:`sandbox-permissions-reference`.
 
 Cleanup
 -------

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -9,4 +9,4 @@ Reference documentation for flatpak and flatpak-builder.
    flatpak-command-reference
    flatpak-builder-command-reference
    available-runtimes
-   sandbox-permissions
+   sandbox-permissions-reference

--- a/docs/sandbox-permissions-reference.rst
+++ b/docs/sandbox-permissions-reference.rst
@@ -1,0 +1,50 @@
+Sandbox Permissions
+===================
+
+Sandbox permissions can be configured from an application manifest file (see :doc:`manifests`). They can also be set with the ``build-finish``, ``run`` and ``override`` commands.
+
+The following list includes many of the most useful permission options. A complete list can be viewed using ``flatpak build-finish --help``.
+
+===================================================  ===========================================
+``--socket=x11``                                     Show windows using X11
+``--share=ipc``                                      Share IPC namespace with the host [#f1]_
+``--device=dri``                                     OpenGL rendering
+``--socket=wayland``                                 Show windows using Wayland
+``--socket=pulseaudio``                              Play sounds using PulseAudio
+``--share=network``                                  Access the network [#f2]_
+``--talk-name=org.freedesktop.secrets``              Talk to a named service on the session bus
+``--system-talk-name=org.freedesktop.GeoClue2``      Talk to a named service on the system bus
+``--socket=system-bus``                              Unlimited access to all of D-Bus
+===================================================  ===========================================
+
+Filesystem permissions
+----------------------
+
+Each of the following permissions configure filesystem access, and should be added to ``--filesystem=``:
+
+====================  ===========================================
+``host``              Access all files
+``home``              Access the home directory
+``/some/dir``         Access an arbitrary path
+``~/some/dir``        Access an arbitrary path relative to the home directory
+``xdg-desktop``       Access the XDG desktop directory
+``xdg-documents``     Access the XDG documents directory
+``xdg-download``      Access the XDG download directory
+``xdg-music``         Access the XDG music directory
+``xdg-pictures``      Access the XDG pictures directory
+``xdg-public-share``  Access the XDG public directory
+``xdg-videos``        Access the XDG videos directory
+``xdg-templates``     Access the XDG templates directory
+====================  ===========================================
+
+Paths can be added to all the above filesystem options. For example, ``--filesystem=xdg-documents/path``. The following permission options can also be added:
+
+- ``:ro`` - read-only access
+- ``:rw`` - read/write access (this is the default)
+- ``:create`` - read/write access, and create the directory if it doesn't exist
+
+.. rubric:: Footnotes
+
+.. [#f1] This is not necessarily required, but without it the X11 shared memory extension will not work, which is very bad for X11 performance.
+.. [#f2] Giving network access also grants access to all host services listening on abstract Unix sockets (due to how network namespaces work), and these have no permission checks. This unfortunately affects e.g. the X server and the session bus which listens to abstract sockets by default. A secure distribution should disable these and just use regular sockets.
+


### PR DESCRIPTION
It's important for the docs to provide guidance on which
sandbox permissions to use, and which to avoid. This commit:

- adds a new page with guidelines, based on the flathub guidelines
- incorporates some of the portals material and expands it
- expands the command reference on sandbox permissions

Fixes issue #89.