### PR TITLE
Add description of base apps (#103)

### DIFF
--- a/docs/building-basics.rst
+++ b/docs/building-basics.rst
@@ -30,6 +30,15 @@ Applications must be built with the SDK that corresponds to their runtime, so th
 Like runtimes, SDKs will sometimes be automatically installed for you, but if you do need to manually install them, they are installed in the same was as applications and runtimes, such as::
 
  $ flatpak install flathub org.gnome.Sdk//3.26
+ 
+Base apps
+--------
+
+Base apps are flatpaks that are used as a starting point when building other applications. They are useful whenever a piece of code must be built and reused several times, but not enough as to merit including it in a runtime.
+
+In order to use a baseapp for building it must be included in your manifest using ``"base":`` and its appid, any application can serve as a base for another.
+
+Unlike with runtimes, users will not need to install the base app in order to run your application.
 
 Bundling
 --------

--- a/docs/building-basics.rst
+++ b/docs/building-basics.rst
@@ -36,7 +36,7 @@ Base apps
 
 Base apps are flatpaks that are used as a starting point when building other applications. They are useful whenever a piece of code must be built and reused several times, but not enough as to merit including it in a runtime.
 
-In order to use a baseapp for building it must be included in your manifest using ``"base":`` and its appid, any application can serve as a base for another.
+In order to use a baseapp for building it must be included in your manifest using ``"base":`` and its appid, any application can serve as a base for another. ``flatpak-builder`` will then start building your application inside the base's sandbox, you will have access to everything already built in the base and it will be bundled into your final application when finished.
 
 Unlike with runtimes, users will not need to install the base app in order to run your application.
 


### PR DESCRIPTION
Because base apps aren't as commonly used in building apps as runtimes and sdks,
they may not merit such a prominent place next to them. However, they are important
for building some kinds of applications and there should at least be a mention of them.