### PR TITLE
Add explanation of build options

### DIFF
--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -76,6 +76,9 @@ The standard guidelines on sandbox permissions apply to Electron applications. H
 Build options
 -------------
 
+These build options aren't strictly necessary, but can be useful if something goes wrong.
+``env`` allows setting an array of environment variables, in this case we set ``NPM_CONFIG_LOGLEVEL`` to ``info`` so that ``npm`` gives us more detailed error messages.
+
 .. code-block:: json
 
   "build-options" : {


### PR DESCRIPTION
Alternatively, it may be good to drop the build options from the guide altogether and document them somewhere else.

npm has nine log levels that can be used to control which errors get logged, all could be used here, but an electron developer would already be familiar with this.

Maybe the important thing is to inform the user that they can set build-time environment variables in the build options, however, this isn't electron specific. It may make more sense to explain this in a more general build system guide.