### PR TITLE
Reinstate the old first build tutorial

### DIFF
--- a/docs/building-introduction.rst
+++ b/docs/building-introduction.rst
@@ -1,0 +1,40 @@
+Building Introduction
+=====================
+
+:doc:`first-build` has already provided a quick demonstration of how applications get built with with Flatpak. This page provides an additional general overview of what's involved.
+
+flatpak-builder
+---------------
+
+``flatpak-builder`` is the primary tool for building Flatpak applications. It allows you to take the source files for an application and build it into a Flatpak application. It also allows multiple other dependencies to be built at the same time, which get bundled into the build.
+
+The input to ``flatpak-builder`` is a manifest file. This specifies the parameters for the application that will be built, such as its name and which runtime it will depend on. The manifest also lists all the modules that are to be built as part of the build process. A source for each module can be specified, including links to file archives or version control repositories. One of the modules (usually the last one) is the application code itself.
+
+The basic format used to invoke ``flatpak-builder`` is::
+
+ $ flatpak-builder <build-dir> <manifest>
+
+Where ``<build-dir>`` is the path to the directory that the application will be built into, and ``<manifest>`` is the path to a manifest file. The contents of ``<directory>`` can be useful for testing and debugging purposes, but is generally treated as an artifact of the build process.
+
+When ``flatpak-builder`` is run:
+
+- The build directory is created, if it doesn't already exist
+- The source code for each module is downloaded and verified
+- The source code for each module is built and installed
+- The build is finished, by setting sandbox permissions
+- The build result is exported to a repository (which will be created if it doesn't exist already)
+
+The application can then be installed from the repository and run.
+
+Software Development Kits (SDKs)
+--------------------------------
+
+Instead of being built using the host environment, Flatpak applications are built inside a separate environment, called an SDK.
+
+SDKs are like the regular runtime that applications run in. The difference is that SDKs also include all the development resources and tools that are required to build an application, such as build and packaging tools, header files, compilers and debuggers.
+
+Each runtime has an accompanying SDK. For example, there is both a GNOME 3.26 runtime and a GNOME 3.26 SDK. Applications that use the runtime are built with the matching SDK.
+
+Like runtimes, SDKs will sometimes be automatically installed for you, but if you do need to manually install them, they are installed in the same was as applications and runtimes, such as::
+
+ $ flatpak install flathub org.gnome.Sdk//3.26

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -1,16 +1,16 @@
 Building
 ========
 
-This section contains detailed information on how to build applications as Flatpaks, including requirements for applications, background information on concepts, guidance on key decisions, detailed information on how to use ``flatpak-builder``, and how to write manifest files.
+This section contains detailed information on how to build applications as Flatpaks. It starts with an overview of the build process, before diving into requirements for applications, guidance on key decisions, information on how to use ``flatpak-builder``, and how to write manifest files.
 
 If you haven't already, it is recommended to run through :doc:`first-build` before reading this section.
 
 .. toctree::
    :maxdepth: 2
 
-
+   building-introduction
    conventions
-   building-basics
+   dependencies
    flatpak-builder
    manifests
    sandbox-permissions

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,14 +1,14 @@
-Setup & Preparation
-===================
+Dependencies
+============
 
-This page provides information on how to get setup in order to build an application. It also provides guidance on some of the key questions that developers have to answer when setting out to build an application with Flatpak for the first time.
+Flatpak provides a number of different options for how applications can depend on other software. When setting out to build an application with Flatpak for the first time, it is therefore necessary to decide how application dependencies will be organized.
 
-Along the way, this page introduces two new concepts: Software Development Kits (SDKs) and base apps.
+This page outlines what the options are, and provides guidance on when to use each one.
 
-Deciding on a runtime
----------------------
+Runtimes
+--------
 
-As was described in the :doc:`basic-concepts`, runtimes provide basic dependencies that can be used by applications. They also provide the environment that applications run in. Flatpak requires each application to specify a runtime. Therefore, one of the first decisions you need to make when building an application with Flatpak, is which runtime it will use.
+As was described in :doc:`basic-concepts`, runtimes provide basic dependencies that can be used by applications. They also provide the environment that applications run in. Flatpak requires each application to specify a runtime. Therefore, one of the first decisions you need to make when building an application with Flatpak, is which runtime it will use.
 
 An overview of the runtimes that are available can be found in the :doc:`available-runtimes` page. There are deliberately only a small number of runtimes to choose from. Typically, runtimes are picked on the basis of which dependencies an application requires. If a runtime exists that provides libraries that you plan on using, this is usually the correct runtime to use!
 
@@ -19,17 +19,6 @@ An overview of the runtimes that are available can be found in the :doc:`availab
 Runtimes are automatically installed for users when they install an application, and build tools can also automatically install them for you (``flatpak-builder``'s ``--install-deps-from`` option is useful for this). However, if you do need to manually install your chosen runtime, this can be done in the same way as installing an application, with the ``flatpak install`` command. For example, the command to install the GNOME 3.26 runtime is::
 
   $ flatpak install flathub org.gnome.Platform//3.26
-
-Software Development Kits (SDKs)
---------------------------------
-
-Each runtime is paired with an SDK (Software Develpment Kit). For example, the GNOME 3.26 runtime is accompanied by the GNOME 3.26 SDK. The SDK includes the same things as the regular runtime, but also includes all the development resources and tools that are required to build an application, such as build and packaging tools, header files, compilers and debuggers.
-
-Applications must be built with the SDK that corresponds to their runtime, so that applications that use the GNOME 3.26 runtime must be built with the GNOME 3.26 SDK.
-
-Like runtimes, SDKs will sometimes be automatically installed for you, but if you do need to manually install them, they are installed in the same was as applications and runtimes, such as::
-
- $ flatpak install flathub org.gnome.Sdk//3.26
 
 Bundling
 --------
@@ -56,6 +45,6 @@ Runtimes and bundling are the two main ways that dependencies are handled with F
 
 However, in some cases, dependencies come as part of a bigger framework or toolkit, which doesn't fit into a runtime but which is also cumbersome to manually bundle as a series of individual modules. This is where *base apps* come in.
 
-Base apps contain collections of bundled dependencies which can then be bundled as part of an applicatio. They don't get rebuilt as part of the build process, which makes building faster (particularly when bundling large dependences). And because each base app is only built once, it is guaranteed to be identical wherever it is used, so it will only be saved once on disk.
+Base apps contain collections of bundled dependencies which can then be bundled as part of an application. They don't get rebuilt as part of the build process, which makes building faster (particularly when bundling large dependences). And because each base app is only built once, it is guaranteed to be identical wherever it is used, so it will only be saved once on disk.
 
-Base apps are a relatively specialized concept and only some applications need to use them. The most common base app is used for `Electron applications <https://github.com/flathub/io.atom.electron.BaseApp>`_. If your application uses a large, complex or specialized framework, it is a good idea to check for available base apps before you start building.
+Base apps are a relatively specialized concept and only some applications need to use them (the most common base app is used for `Electron applications <https://github.com/flathub/io.atom.electron.BaseApp>`_). However, if your application uses a large, complex or specialized framework, it is a good idea to check for available base apps before you start building.

--- a/docs/first-build.rst
+++ b/docs/first-build.rst
@@ -1,98 +1,131 @@
-Your First Build
-================
+Building your first Flatpak
+===========================
 
-This tutorial provides a quick, step-by-step example of how to build a simple application using Flatpak.
+This tutorial provides a quick introduction to building Flatpaks. In it, you will learn how to create a basic Flatpak application, which can be installed and run.
 
 In order to complete this tutorial, you should have followed the `setup guide on flatpak.org <http://flatpak.org/setup/>`_. You also need to have installed ``flatpak-builder``, which is usually available from the same repository as the ``flatpak`` package.
 
-1. Create a manifest
---------------------
+1. Install a runtime and the matching SDK
+-----------------------------------------
 
-``flatpak-builder`` is the primary tool for building Flatpaks. The input to ``flatpak-builder`` is a JSON file that describes the parameters for building the application. This is called the manifest. The following example is the manifest for the GNOME Dictionary application:
+Flatpak requires every app to specify a runtime that it uses for its basic
+dependencies. Each runtime has a matching SDK (Software Development Kit), which
+contains all the things that are in the runtime, plus headers and development
+tools. This SDK is required to build apps for the runtime.
+
+In this tutorial we will use the Freedesktop 1.6 runtime and SDK. To install these, run::
+
+  $ flatpak install flathub org.freedesktop.Platform//1.6 org.freedesktop.Sdk//1.6
+
+2. Create the app
+-----------------
+
+The app that is going to be created for this tutorial is a simple script. To
+create it, copy the following::
+
+  #!/bin/sh
+  echo "Hello world, from a sandbox"
+
+Now paste this into an empty file and save it as ``hello.sh``.
+
+3. Add a manifest
+-----------------
+
+Each Flatpak is built using a manifest file which provides basic information about the application and instructions for how it is to be built. To add a manifest to the hello world app, add the following to an empty file:
 
 .. code-block:: json
 
   {
-    "app-id": "org.gnome.Dictionary",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
-    "sdk": "org.gnome.Sdk",
-    "command": "gnome-dictionary",
-    "finish-args": [
-       "--socket=x11",
-       "--share=network"
-    ],
-    "modules": [
-      {
-        "name": "gnome-dictionary",
-        "sources": [
+      "app-id": "org.flatpak.Hello",
+      "runtime": "org.freedesktop.Platform",
+      "runtime-version": "1.6",
+      "sdk": "org.freedesktop.Sdk",
+      "command": "hello.sh",
+      "modules": [
           {
-            "type": "archive",
-            "url": "https://download.gnome.org/sources/gnome-dictionary/3.26/gnome-dictionary-3.26.0.tar.xz",
-            "sha256": "387ff8fbb8091448453fd26dcf0b10053601c662e59581097bc0b54ced52e9ef"
+              "name": "hello",
+              "buildsystem": "simple",
+              "build-commands": [
+                  "install -D hello.sh /app/bin/hello.sh"
+              ],
+              "sources": [
+                  {
+                      "type": "file",
+                      "path": "hello.sh"
+                  }
+              ]
           }
-        ]
-      }
-    ]
+      ]
   }
 
-As can be seen, this manifest includes basic information about the application, including:
+Now save the file alongside ``hello.sh`` and call it ``org.flatpak.Hello.json``.
 
-- ``app-id`` - the application ID
-- ``runtime`` - the runtime, which provides the environment that the application will run in, as well as basic dependencies it can use
-- ``sdk`` - the Software Development Kit, which is a version of the runtime with development files and headers; this is required to build the app
-- ``command`` - the command that is used to run the application
-- ``finish-args`` - configuration options which give the application access to resources outside of its sandbox; in this case, the application is being given network access and access to the X11 display server
+In a more complex application, the manifest would list multiple modules. The
+last one would typically be the application itself, and the earlier ones would
+be dependencies that are bundled with the app because they are not part of the
+runtime.
 
-The next part of the manifest is the ``modules`` list. This describes each of the modules that are to be built as part of the build process. One of these modules is always the application. Others can be libraries and other resources that are bundled as part of the application.
+4. Build the application
+------------------------
 
-Module sources can be of several types, including ``.tar`` or ``.zip`` archives, Git or Bzr repositories. In this case, there is only one module, which is a ``.tar`` file which will be downloaded and built.
+Now that the app has a manifest, ``flatpak-builder`` can be used to build it.
+This is done by specifying the manifest file and a target directory::
 
-The modules section of the Dictionary manifest is short, because only one module is built: the application itself.
+  $ flatpak-builder build-dir org.flatpak.Hello.json
 
-To create a manifest for the Dictionary, create a file called ``org.gnome.Dictionary.json`` and paste the JSON from above into it.
+This command will build each module that is listed in the manifest and install
+it to the ``/app`` subdirectory, inside the ``build-dir`` directory.
 
-2. Run the build
-----------------
+5. Test the build
+-----------------
 
-To use the manifest to build the Dictionary application, run the following command::
+To verify that the build was successful, run the following::
 
-  $ flatpak-builder --repo=tutorial-repo dictionary org.gnome.Dictionary.json
+  $ flatpak-builder --run build-dir org.flatpak.Hello.json hello.sh
 
-This will:
+Congratulations, you've made an app!
 
-* Create a new directory called dictionary
-* Download and verify the Dictionary source code
-* Build and install the source code, inside the SDK rather than the host system
-* Finish the build, by setting permissions (in this case giving access to X11 and the network)
-* Create a new repository called repo (if it doesn't exist) and export the resulting build into it
+6. Put the app in a repository
+------------------------------
 
-``flatpak-builder`` will also do some other useful things, like creating a separately installable debug runtime (called ``org.gnome.Dictionary.Debug`` in this case) and a separately installable translation runtime (called ``org.gnome.Dictionary.Locale``).
+Before you can install and run the app, it first needs to be put in a
+repository. This is done by passing the ``--repo`` argument to ``flatpak-builder``::
 
-3. Add the new repository
--------------------------
+ $ flatpak-builder --repo=repo --force-clean build-dir org.flatpak.Hello.json
 
-To test the application that has been built, you need to add the new repository that has been created::
+This does the build again, and at the end exports the result to a local
+directory called ``repo``. Note that ``flatpak-builder`` keeps a cache of previous
+builds in the ``.flatpak-builder`` subdirectory, so doing a second build like
+this is very fast.
 
-  $ flatpak --user remote-add --no-gpg-verify --if-not-exists tutorial-repo tutorial-repo
+This second time we passed in ``--force-clean``, which means that the previously
+created ``build-dir`` directory was deleted before the new build was started.
 
-4. Install the application
---------------------------
+7. Install the app
+------------------
 
-The next step is to install the Dictionary application from the repository. To do this, run::
+Now we're ready to add the repository that was just created and install the
+app. This is done with two commands::
 
-  $ flatpak --user install tutorial-repo org.gnome.Dictionary
+  $ flatpak --user remote-add --no-gpg-verify tutorial-repo repo
+  $ flatpak --user install tutorial-repo org.flatpak.Hello
 
-To check that the application has been successfully installed, you can compare the sha256 commit of the installed app with the commit ID that was printed by ``flatpak-builder``::
+The first command adds the repository that was created in the previous step.
+The second command installs the app from the repository.
 
-  $ flatpak info org.gnome.Dictionary
-  $ flatpak info org.gnome.Dictionary.Locale
+Both these commands use the ``--user`` argument, which means that the repository
+and the app are added per-user rather than system-wide. This is useful for testing.
 
-5. Run the application
-----------------------
+Note that the repository was added with ``--no-gpg-verify``, since a GPG key
+wasn't specified when the app was built. This is fine for testing, but for
+official repositories you should sign them with a private GPG key.
 
-Finally, you can run the application that you've built::
+8. Run the app
+--------------
 
-  $ flatpak run org.gnome.Dictionary
+All that's left is to try the app. This can be done with the following command::
 
-The rest of the documentation provides a complete guide to using ``flatpak-builder``. If you are new to Flatpak, it is recommended to start with the :doc:`introduction`.
+  $ flatpak run org.flatpak.Hello
+
+This runs the app, so that it prints 'Hello world, from a sandbox'.
+

--- a/docs/flatpak-builder.rst
+++ b/docs/flatpak-builder.rst
@@ -1,18 +1,7 @@
 Flatpak Builder
 ===============
 
-``flatpak-builder`` has already been introduced in :doc:`first-build`, which gave a basic example of how it can be used. This page provides additional detail on how to use ``flatpak-builder``, including the various command options that are available.
-
-Invocation
-----------
-
-The basic format used to invoke ``flatpak-builder`` is::
-
- $ flatpak-builder <directory> <manifest>
-
-Where ``<directory>`` is the path to the directory that the application will be built into, and ``<manifest>`` is the path to a manifest JSON file.
-
-The contents of ``<directory>`` can be useful for testing and debugging purposes, but is generally treated as an artifact of the build process.
+``flatpak-builder`` has already been introduced in :doc:`first-build` and :doc:`building-introduction`. This page provides additional detail on how to use ``flatpak-builder``, including the various command options that are available.
 
 Exporting
 ---------
@@ -24,9 +13,9 @@ Exporting to a repository
 
 The ``--repo`` option allows a repository to be specified, for the application to be exported to. This takes the format::
 
- $ flatpak-builder --repo=<repository> <directory> <manifest>
+ $ flatpak-builder --repo=<repo> <build-dir> <manifest>
 
-Here, ``<repository>`` is a path to a repository. If no repository exists at the specified location, the repository will be created. If the application is already in the specified repository, ``flatpak-builder`` will add the build as a new version of the existing application.
+Here, ``<repo>`` is a path to a repository. If no repository exists at the specified location, the repository will be created. If the application is already in the specified repository, ``flatpak-builder`` will add the build as a new version of the existing application.
 
 .. note::
 
@@ -38,7 +27,7 @@ Installing builds directly
 
 Instead of exporting to a repository, the Flatpak that is produced by ``flatpak-builder`` can be automatically installed locally, using the ``--install`` option::
 
-  $ flatpak-builder --install <directory> <manifest>
+  $ flatpak-builder --install <build-dir> <manifest>
 
 This approach has the advantage of skipping the separate install step that is needed when exporting to a repository.
 


### PR DESCRIPTION
The old first build tutorial used a hello-world script rather
than an prexisting app. The steps for creating a manifest were
useful for showing how Flatpak works.

This commit reinstates the old hello-world-based tutorial. Some
restructuring is necessary as a result.