### PR TITLE
Add a page on desktop integration

### DIFF
--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -1,17 +1,32 @@
-Conventions & Requirements
+Requirements & Conventions
 ==========================
 
-Flatpak deliberately makes as few requirements of applications as possible. However, a small number of standard Linux desktop conventions are expected, primarily to ensure that applications integrate with Linux desktops and app centers. These are listed below.
+Flatpak deliberately makes as few requirements of applications as possible. However, a small number of standard Linux desktop conventions are expected, primarily to ensure that applications integrate with Linux desktops and app centers. Developers might also encounter a small number of Linux technical conventions.
 
-Applications that have previously targeted the Linux desktop will typically need to make very few (if any) changes to conform with these standards.
+Information on further desktop integration options can be found in :doc:`desktop-integration`.
+
+Expected Standards
+------------------
+
+Applications that use Flatpak are generally expected to comply with the following standards. Applications that have previously targeted the Linux desktop will typically need to make very few (if any) changes to do this.
 
 Application IDs
----------------
+```````````````
 
 As described in :doc:`using-flatpak`, Flatpak requires each application to have a unique identifier, which has a three-part form such as ``org.gnome.Dictionary``. As will be seen below and in future sections, this ID is expected to be used in a number of places. Developers should follow the standard `D-Bus naming conventions <https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names>`_ when creating their own IDs. This format is already recommended by the `Desktop File specification  <https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#file-naming>`_ and `Appstream specification  <https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent>`_ also.
 
+AppData files
+`````````````
+AppData files provide metadata about applications, which is used by application stores (such as Flathub, GNOME Software and KDE Discover). The `Freedesktop AppStream specification <https://www.freedesktop.org/software/appstream/docs/>`_ provides a complete reference for providing AppData.
+
+AppData files should be named with the application ID and the ``.appdata.xml`` file extension, and should be placed in ``/app/share/metainfo/``. For example::
+
+  /app/share/metainfo/org.gnome.Dictionary.appdata.xml
+
+The ``appstream-util validate-relax`` command can be used to check AppData files for errors.
+
 Application icons
------------------
+`````````````````
 
 Applications are expected to provide an application icon, which is used for their application launcher. These icons should be provided in accordance with the `Freedesktop icon specification <https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html>`_.
 
@@ -24,9 +39,9 @@ For example, the path to the 128✕128px version of GNOME Dictionary's icon is::
   /app/share/icons/hicolor/128x128/apps/org.gnome.Dictionary.png
 
 Desktop files
--------------
+`````````````
 
-Desktop files are another Freedesktop standard, which is used to provide the desktop environment with information about each application. The `Freedesktop specification <https://standards.freedesktop.org/desktop-entry-spec/latest/>`_ provides a complete reference for writing desktop files, and `additional information about them <https://wiki.archlinux.org/index.php/desktop_entries>`_ is available online.
+Desktop files are used to provide the desktop environment with information about each application. The `Freedesktop specification <https://standards.freedesktop.org/desktop-entry-spec/latest/>`_ provides a complete reference for writing desktop files, and `additional information about them <https://wiki.archlinux.org/index.php/desktop_entries>`_ is available online.
 
 Desktop files should be named with the application's ID, followed by the ``.desktop`` file extension, and should be placed in ``/app/share/applications/``. For example::
 
@@ -42,23 +57,35 @@ A minimal desktop file should contain at least the application's *name*, *exec* 
 
 The ``desktop-file-validate`` command can be used to check for errors in desktop files.
 
-AppData files
--------------
+Technical conventions
+---------------------
 
-AppData files provide metadata about applications, which is used by application stores (such as Flathub, GNOME Software and KDE Discover). The `Freedesktop AppStream specification <https://www.freedesktop.org/software/appstream/docs/>`_ provides a complete reference for providing AppData.
+The following are standard technical conventions used by Flatpak and Linux desktops. Those with Linux experience likely already be aware of them. However, developers who are new to Linux might find some of this information useful.
 
-AppData files should be named with the application ID and the ``.appdata.xml`` file extension, and should be placed in ``/app/share/metainfo/``. For example::
+D-Bus
+`````
 
-  /app/share/metainfo/org.gnome.Dictionary.appdata.xml
+D-Bus is the standard IPC framework used on Linux desktops. A lot of applications won't need to use it, but it is supported by Flatpak should it be required.
 
-The ``appstream-util validate-relax`` command can be used to check AppData files for errors.
+D-Bus can be used for application launching and communicating with some system services. Applications can also provide their own D-Bus services (when doing this, the D-Bus service name is expected to be the same as the application ID).
+
+Filesystem layout
+`````````````````
+
+Each Flatpak sandbox, which is the environment in which an application is run, contains the filesystem of the application's runtime. This follows `standard Linux filesystem conventions <https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard>`_.
+
+For example, the root of the sandbox contains the ``/etc`` directory for configuration files and ``/usr`` for multi-user utilities and applications. In addition to this, each sandbox contains a top-level ``/app`` directory, which is where the application's own files are located.
 
 XDG base directories
 --------------------
 
-`XDG base directories <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_ are a Freedesktop standard which defines standard locations where user-specific application data and configuration should be stored. If your application already respects these nothing must be changed.
+`XDG base directories <https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_ are standard locations for user-specific application data. Popular toolkits provide convenience functions for accessing XDG base directories. These include:
 
-By default, Flatpak sets three XDG base directories that should be used by applications for user-specific storage. These are:
+- Electron: XDG base directories can be accessed with ``app.getPath``
+- Glib: provides access to the XDG base directories through the ``g_get_user_cache_dir ()``, ``g_get_user_data_dir ()``, ``g_get_user_config_dir ()`` functions
+- Qt: provides access to XDG base directories with the the `QStandardPaths Class <http://doc.qt.io/qt-5/qstandardpaths.html>`_
+
+However, applications that aren't using one of these toolkits can expect to find their XDG base directories in the following locations:
 
 ===============  =================================  ==========================
 Base directory   Usage                              Default location
@@ -73,15 +100,3 @@ For example, GNOME Dictionary will store user-specific data in::
   ~/.var/org.gnome.Dictionary/data/gnome-dictionary
 
 Note that applications can be configured to use non-default base directory locations (see :doc:`sandbox-permissions`).
-
-Filesystem layout
------------------
-
-Each Flatpak sandbox, which is the environment in which an application is run, contains the filesystem of the application's runtime. This follows `standard Linux filesystem conventions <https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard>`_.
-
-For example, the root of the sandbox contains the ``/etc`` directory for configuration files and ``/usr`` for multi-user utilities and applications. In addition to this, each sandbox contains a top-level ``/app`` directory, which is where the application's own files are located.
-
-D-Bus
------
-
-Flatpak supports `D-Bus <https://www.freedesktop.org/wiki/Software/dbus/>`_, the standard framework for inter-process communication on Linux desktops. This can be used for application launching and communicating with some system services. Applications can also provide their own D-Bus services (when doing this, the D-Bus service name is expected to be the same as the application ID).

--- a/docs/desktop-integration.rst
+++ b/docs/desktop-integration.rst
@@ -1,0 +1,70 @@
+Desktop Integration
+===================
+
+:doc:`conventions` covers the essential aspects of Linux desktop integration. This page provides further information on optional desktop integration features. It also provides guidance on how applications can ensure that their user interfaces fit into the whole range of Linux desktops and distributions.
+
+This information is primarily intended for developers who are new to Linux. However it is also relevant to desktop-specific Linux applications who wish to target a broader range of Linux environments.
+
+While targeting the Linux desktop ecosystem might seem challenging, the existence of common standards, in combination with these guidelines, means that supporting the full range of Linux environments needn't be difficult.
+
+Locale detection
+----------------
+
+Application toolkits, such as Electron, GTK and Qt, provide built-in support for detecting which locale to use. Otherwise, the ``setlocale`` function can be used.
+
+Portals
+-------
+
+Portals are the framework for securely accessing resources from outside an application sandbox. They provide a range of common features to applications, including:
+
+- Determining network status
+- Opening a file with a file chooser
+- Opening URIs
+- Preventing the device from suspend/sleep/powering off
+- Printing
+- Sending email
+- Showing notifications
+- Taking screenshots and screencasts
+
+Toolkits like GTK and Qt provide transparent support for portals. If you are not using one of these toolkits, it is possible to access the portals API directly. See the `portals API documentation <https://flatpak.github.io/xdg-desktop-portal/portal-docs.html>`_ for more information.
+
+Notifications
+-------------
+
+A number of toolkits and frameworks provide transparent support for Linux desktop notificatoions. This includes Electron, GTK, KDE and QML. Applications not using one of these can either use the `libnotify <https://developer.gnome.org/libnotify/>`_ library or portals. Of these, portals has the benefit that it can easily be used from within an application sandbox.
+
+Status icons
+------------
+
+Status icons are the same concept as the system tray or the taskbar on Windows, or menu bar icons on Mac. These are supported on most Linux distributions, through libappindicator.
+
+A number of Linux distributions don't show status icons. It is still possible to provide a status icon, and it will be shown in some distributions. However, in order to ensure compatibility, it is recommended to only use status icons in a supplementary manner, and not to rely on them as the only mechanism for providing status information or access to particular features. This includes "minimize to tray" (or equivalent) functionality.
+
+System search
+-------------
+
+GNOME-based distributions, like CentOS, Fedora, Red Hat Enterprise Linux and Ubuntu, provide the option to integrate with system search, by providing a `search provider <https://developer.gnome.org/SearchProvider/>`_. This allows application-provided search results to appear in the Activities Overview.
+
+Window controls
+---------------
+
+Window controls are the buttons used to close, maximize and minimize windows. These do vary across Linux desktops, particularly in terms of which controls are shown. Whether applications attempt to follow these variations is up to their discretion. Providing the exact same controls as used by a particular desktop environment should not be seen as a hard requirement.
+
+From a user experience perspective, it is important to ensure that window controls appear on the same side of the window as other desktops. On Linux this is the right side of the window (like Windows).
+
+Applications can rely on system-provided titlebars on Linux, if they don't want to draw their own window controls.
+
+Window decorations
+------------------
+
+If your application uses a dark visual style as well as system-provided window decorations, the ``GTK_THEME_VARIANT=dark`` X11 window property should be used, to ensure that window decorations match the rest of the application window. This can be done by running::
+
+  xprop -f _GTK_THEME_VARIANT 8u -set _GTK_THEME_VARIANT dark
+
+Defunct integration options
+---------------------------
+
+The following desktop integration options are no longer in use and can be safely ignored:
+
+- Application menus - these are specific to the GNOME desktop. However, they are likely to be phased out in the future.
+- Global menu bar - this was a feature similar to Mac's menu bar, which was part of Ubuntu's Unity desktop. This has been retired. All Linux desktops and distributions expect a menu bar to be shown as part of the application window, should one be provided (rather than relying on a global menu bar, as on Mac).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,4 +18,5 @@ Contents
    building
    debugging
    publishing
+   desktop-integration
    reference  


### PR DESCRIPTION
Targeting the Linux desktop ecosystem can be daunting. We should
try and make it easier.