### PR TITLE
Point to source for command reference docs

### DIFF
--- a/docs/flatpak-builder-command-reference.rst
+++ b/docs/flatpak-builder-command-reference.rst
@@ -1,5 +1,9 @@
 Flatpak Builder Command Reference
 =================================
 
+..
+  The command reference is generated from the flatpak-builder repo - see
+  https://github.com/flatpak/flatpak-builder/tree/master/doc
+
 .. raw:: html
    :file: flatpak-builder-docs.html

--- a/docs/flatpak-command-reference.rst
+++ b/docs/flatpak-command-reference.rst
@@ -1,5 +1,9 @@
 Flatpak Command Reference
 =========================
 
+..
+  The command reference is generated from the flatpak repo - see
+  https://github.com/flatpak/flatpak/tree/master/doc
+
 .. raw:: html
    :file: flatpak-docs.html


### PR DESCRIPTION
I wanted to contribute to the reference docs, and was temporarily confused about where they come from. So once I worked it out, I thought I'd clarify it for anyone else who reaches the same place.

The `..` syntax is a rst comment, so these messages are only visible to people looking at the docs source.