### PR TITLE
first-build.rst -- add disclaimer about --run

### DIFF
--- a/docs/first-build.rst
+++ b/docs/first-build.rst
@@ -85,6 +85,8 @@ To verify that the build was successful, run the following::
 
 Congratulations, you've made an app!
 
+Keep in mind that using ``--run`` won't result in a sandbox with the same permissions as the final app, as such it shouldn't be relied upon beyond basic testing.
+
 6. Put the app in a repository
 ------------------------------
 


### PR DESCRIPTION
This question pops up frequently in the irc channel, it's a common hurdle for new users.
They test using --run and everything is fine, but their application inexplicably breaks when they do the final build.
It may be better to modify flatpak-builder so that --run works in the expected way, but in the mean time it'll be helpful to new users if this is explained.