### PR TITLE
Changing `runtime-version` in manifest codeblock.

### DIFF
--- a/docs/first-build.rst
+++ b/docs/first-build.rst
@@ -38,7 +38,7 @@ Each Flatpak is built using a manifest file which provides basic information abo
   {
       "app-id": "org.flatpak.Hello",
       "runtime": "org.freedesktop.Platform",
-      "runtime-version": "1.6",
+      "runtime-version": "18.08",
       "sdk": "org.freedesktop.Sdk",
       "command": "hello.sh",
       "modules": [


### PR DESCRIPTION
Installed runtime in:

```bash
$ flatpak install flathub org.freedesktop.Platform//18.08 org.freedesktop.Sdk//18.08
```
is `18.08`, changing manifest example to reflect that.