### PR TITLE
Add a link to the libflatpak docs

### DIFF
--- a/docs/libflatpak-api-reference.rst
+++ b/docs/libflatpak-api-reference.rst
@@ -1,0 +1,5 @@
+libflatpak API Reference
+========================
+
+.. raw:: html
+   <http://flatpak.github.io/flatpak/reference/html/index.html>

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,7 +1,7 @@
 Reference Documentation
 =======================
 
-Reference documentation for flatpak and flatpak-builder.
+Reference documentation for flatpak, flatpak-builder and libflatpak.
 
 .. toctree::
    :maxdepth: 2
@@ -12,3 +12,4 @@ Reference documentation for flatpak and flatpak-builder.
    sandbox-permissions-reference
    freedesktop-quick-reference
    under-the-hood
+   libflatpak-api-reference


### PR DESCRIPTION
Just for completeness, it is nice to have a link to the
library docs here as well.