### PR TITLE
Mention that YAML is also supported for manifests

### DIFF
--- a/docs/manifests.rst
+++ b/docs/manifests.rst
@@ -1,7 +1,7 @@
 Manifests
 =========
 
-The input to ``flatpak-builder`` is a JSON file that describes the parameters for building an application, as well as instructions for each of the modules that are to be built. This file is called the manifest.
+The input to ``flatpak-builder`` is a JSON or YAML file that describes the parameters for building an application, as well as instructions for each of the modules that are to be built. This file is called the manifest.
 
 This page provides information and guidance on how to use manifests, including an explanation of the most common parameters that can be specified. It is recommended to have followed the :doc:`first-build` tutorial before reading this section, and to be familiar with :doc:`flatpak-builder`.
 


### PR DESCRIPTION
https://blogs.gnome.org/alexl/2018/05/04/yamling-the-flathub/ claims flatpak-builder supports YAML starting with version 0.10.10