### PR TITLE
Add details about GTK portal support

### DIFF
--- a/docs/desktop-integration.rst
+++ b/docs/desktop-integration.rst
@@ -26,7 +26,7 @@ Portals are the framework for securely accessing resources from outside an appli
 - Showing notifications
 - Taking screenshots and screencasts
 
-Toolkits like GTK and Qt provide transparent support for portals. If you are not using one of these toolkits, it is possible to access the portals API directly. See the `portals API documentation <https://flatpak.github.io/xdg-desktop-portal/portal-docs.html>`_ for more information.
+Toolkits like GTK and Qt provide transparent support for portals. See :doc:`portals-gtk` for detailed information about GTK and portals. If you are not using one of these toolkits, it is possible to access the portals API directly. See the `portals API documentation <https://flatpak.github.io/xdg-desktop-portal/portal-docs.html>`_ for more information.  
 
 Notifications
 -------------

--- a/docs/portals-gtk.rst
+++ b/docs/portals-gtk.rst
@@ -1,0 +1,14 @@
+Portal support in GTK
+=====================
+
+GTK will transparently use portals for some functionality when it detects that it is being
+used inside a Flatpak sandbox. Here are some hints for what GTK applications should do to
+benefit from this.
+
+- Use ``g_get_user_config_dir()``, ``g_get_user_cache_dir()`` and ``g_get_user_data_dir()`` to find the right place to store configuration and data
+- Use ``GtkFileChooserNative`` (or ``GtkFileChooserButton``) to open files. Note that portals cannot currently give access to directories on the host filesystem
+- Use ``GtkPrintOperation`` for printing
+- Use ``gtk_show_uri_on_window()`` or ``g_app_info_launch_default_for_uri()`` to open URIs
+- Use ``gtk_application_inhibit()`` if you want to inhibit idle or logout
+- Use ``g_application_send_notification()`` to show notifications
+- Use the ``GtkApplication::screensaver-active`` property to monitor scrensaver status


### PR DESCRIPTION
Add a page that points out specific apis to use for transparent portal support.

Closes: #166 