### PR TITLE
Use a bolder font for headings

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -13,9 +13,9 @@ body {
   font-family: "Source Sans Pro", sans-serif;
 }
 
-h1,h2,h3,h4,h5,h6 {
+h1, h2, h3, h4, h5, h6 {
   font-family: "Overpass", sans-serif;
-  font-weight: 200;
+  font-weight: 600;
 }
 
 a.icon-home, a.icon-home:hover {


### PR DESCRIPTION
This makes headings easier to read.

### Preview

#### Before (loDPI)

![flatpak_doc_old_lodpi](https://user-images.githubusercontent.com/180032/52872792-a90daf80-314d-11e9-8134-b394859f332a.png)

#### After (loDPI)

![flatpak_doc_new_lodpi](https://user-images.githubusercontent.com/180032/52872790-a8751900-314d-11e9-8032-cc26249803f7.png)

#### Before (hiDPI)

![flatpak_doc_old_hidpi](https://user-images.githubusercontent.com/180032/52872791-a90daf80-314d-11e9-8a20-ab815753adbb.png)


#### After (hiDPI)

![flatpak_doc_new_hidpi](https://user-images.githubusercontent.com/180032/52872789-a8751900-314d-11e9-8ec0-1cae779342c6.png)