### PR TITLE
Optimize CSS delivery

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,13 +1,4 @@
-/* Original Stylesheet */
-@import url("https://media.readthedocs.org/css/sphinx_rtd_theme.css");
-
 /* GNOME Overrides */
-
-/* Overpass for headings */
-@import url("http://overpass-30e2.kxcdn.com/overpass.css");
-
-/* Source Sans for text */
-@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:700,700i,400,400i&amp;subset=latin-ext");
 
 body {
   font-family: "Source Sans Pro", sans-serif;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,6 +91,7 @@ html_theme = 'sphinx_rtd_theme'
 html_context = {
     'css_files': [
         '_static/theme_overrides.css', #GNOME specific overrides
+        'https://fonts.googleapis.com/css?family=Overpass:400,600,700|Source+Sans+Pro:400,400i,700,700i&display=swap&subset=latin-ext', # Web fonts
         ],
     }
 


### PR DESCRIPTION
- Load stylesheets in `conf.py` instead of using `@import` to make parallel requests possible
- Don't import `sphinx_rtd_theme.css` as it's already loaded by the theme
- Source both web fonts using a single request to Google Fonts
- Use `display: swap` in Web fonts for faster display