### PR TITLE
docs/first-build.rst: Clarify --run permissions

### DIFF
--- a/docs/first-build.rst
+++ b/docs/first-build.rst
@@ -95,9 +95,9 @@ To verify that the build was successful, run the following::
 
 Congratulations, you've made an app!
 
-Keep in mind that using ``--run`` won't result in a sandbox with the same
-permissions as the final app, as such it shouldn't be relied upon beyond
-basic testing.
+Using ``--run`` results in a sandbox with mostly the same permissions as the
+final app, with the exception of filesystem permissions. As such it shouldn't
+be relied upon beyond basic testing.
 
 6. Put the app in a repository
 ------------------------------


### PR DESCRIPTION
It's confusing if here we say that flatpak-builder --run doesn't use the
same permissions as the final app, but in the man page it says that
--run does use the same permissions. So update the wording here to be
more specific.