### PR TITLE
run flatpak update as root to avoid min-free-space-size error

### DIFF
--- a/docs/using-flatpak.rst
+++ b/docs/using-flatpak.rst
@@ -169,7 +169,7 @@ Updating
 To update all your installed applications and runtimes to the latest version,
 run::
 
- $ flatpak update
+ # flatpak update
 
 List installed applications
 ```````````````````````````


### PR DESCRIPTION
Or otherwise running `flatpak update` as non root will result in `min-free-space-size 500MB would be exceeded` error. 