### PR TITLE
Fixed formatting issue with Building Introduction article

### DIFF
--- a/docs/building-introduction.rst
+++ b/docs/building-introduction.rst
@@ -35,9 +35,9 @@ When ``flatpak-builder`` is run:
 - The build directory is created, if it doesn't already exist
 - The source code for each module is downloaded and verified
 - The source code for each module is built and installed
-- The build is finished, by setting sandbox permissions
+- The build is finished by setting sandbox permissions
 - The build result is exported to a repository (which will be created if it
-doesn't exist already)
+  doesn't exist already)
 
 The application can then be installed from the repository and run.
 


### PR DESCRIPTION
This PR fixes a grammar error and formatting error on the "Building Introduction" article in the docs.