### PR TITLE
Fixes syntax of bullet list, footnote, json highlighting and duplicate target name

### DIFF
--- a/docs/building-introduction.rst
+++ b/docs/building-introduction.rst
@@ -37,7 +37,7 @@ When ``flatpak-builder`` is run:
 - The source code for each module is built and installed
 - The build is finished, by setting sandbox permissions
 - The build result is exported to a repository (which will be created if it
-doesn't exist already)
+  doesn't exist already)
 
 The application can then be installed from the repository and run.
 

--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -45,11 +45,13 @@ ID. It also configures the runtime and SDK:
 
 .. code-block:: json
 
-    "app-id": "org.flathub.electron-sample-app",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
-    "branch": "stable",
-    "sdk": "org.freedesktop.Sdk",
+    {
+      "app-id": "org.flathub.electron-sample-app",
+      "runtime": "org.freedesktop.Platform",
+      "runtime-version": "1.6",
+      "branch": "stable",
+      "sdk": "org.freedesktop.Sdk",
+    }
 
 The Freedesktop runtime is generally the best runtime to use with Electron
 applications, since it is the most minimal runtime, and other dependencies
@@ -83,7 +85,9 @@ later.
 
 .. code-block:: json
 
-  "command": "run.sh",
+  {
+    "command": "run.sh",
+  }
 
 Sandbox permissions
 -------------------
@@ -95,12 +99,14 @@ pulseaudio for sound and enables network access:
 
 .. code-block:: json
 
-  "finish-args": [
-      "--share=ipc",
-      "--socket=x11",
-      "--socket=pulseaudio",
-      "--share=network"
-  ],
+  {
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--share=network"
+    ],
+  }
 
 Build options
 -------------
@@ -113,13 +119,15 @@ error messages.
 
 .. code-block:: json
 
-  "build-options" : {
-      "cflags": "-O2 -g",
-      "cxxflags": "-O2 -g",
-      "env": {
-          "NPM_CONFIG_LOGLEVEL": "info"
-      }
-  },
+  {
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "NPM_CONFIG_LOGLEVEL": "info"
+        }
+    },
+  }
 
 Building Node.js
 ----------------
@@ -164,12 +172,14 @@ can be found.
 
 .. code-block:: json
 
-  "name": "electron-sample-app",
-  "build-options" : {
-      "env": {
-          "electron_config_cache": "/run/build/electron-sample-app/npm-cache"
-      }
-  },
+  {
+    "name": "electron-sample-app",
+    "build-options" : {
+         "env": {
+            "electron_config_cache": "/run/build/electron-sample-app/npm-cache"
+        }
+    },
+  }
 
 By default, ``flatpak-builder`` doesn't allow build tools to access the
 network. This means that tools which rely on downloading sources will not
@@ -184,14 +194,17 @@ and hash of the application are also specified.
 
 .. code-block:: json
 
-  "buildsystem": "simple",
-  "sources": [
-    {
-        "type": "archive",
-        "url": "https://github.com/flathub/electron-sample-app/archive/1.0.1.tar.gz",
-        "sha256": "a2feb3f1cf002a2e4e8900f718cc5c54db4ad174e48bfcfbddcd588c7b716d5b",
-        "dest": "main"
-    },
+  {
+    "buildsystem": "simple",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/flathub/electron-sample-app/archive/1.0.1.tar.gz",
+            "sha256": "a2feb3f1cf002a2e4e8900f718cc5c54db4ad174e48bfcfbddcd588c7b716d5b",
+            "dest": "main"
+        },
+    ],
+  }
 
 Bundling NPM packages
 ---------------------
@@ -200,7 +213,9 @@ The next line is how NPM modules get bundled as part of Flatpaks:
 
 .. code-block:: json
 
-  "generated-sources.json",
+  {
+    "generated-sources.json",
+  }
 
 Since even simple Node.js applications depend on dozens of packages, it would
 be impractical to specify all of them as part of a manifest file. A `Python
@@ -227,11 +242,11 @@ Launching the app
 -----------------
 
 The Electron app is run through a simple script. This can be given any name
-but must be specified in the manifest's ``"command":`` property.
+but must be specified in the manifest's ``"command":`` property. See below
+a sample wrapper for launching app:
 
 .. code-block:: json
 
-  /* Wrapper to launch the app */
   {
     "type": "script",
     "dest-filename": "run.sh",
@@ -243,19 +258,17 @@ Build commands
 
 Last but not least, since the simple build option is being used, a list of
 build commands must be provided. As can be seen, ``npm`` is run with the
-``--offline`` option, using packages that have already been cached. These
-are copied to ``/app/main/``. Finally the ``run.sh`` script is installed to
-``/app/bin/`` so that it will be on ``$PATH``:
+``--offline`` option, installing dependencies from packages that have already
+been cached. These are copied to ``/app/main/``. Finally the ``run.sh`` script
+is installed to ``/app/bin/`` so that it will be on ``$PATH``:
 
 .. code-block:: json
 
-  "build-commands": [
-      /* Install npm dependencies */
-      "npm install --prefix=main --offline --cache=/run/build/electron-sample-app/npm-cache/",
-      /* Bundle app and dependencies */
-      "mkdir -p /app/main /app/bin",
-      "cp -ra main/* /app/main/",
-      /* Install app wrapper */
-      "install run.sh /app/bin/"
-  ]
-
+  {
+    "build-commands": [
+        "npm install --prefix=main --offline --cache=/run/build/electron-sample-app/npm-cache/",
+        "mkdir -p /app/main /app/bin",
+        "cp -ra main/* /app/main/",
+        "install run.sh /app/bin/"
+    ]
+  }

--- a/docs/manifests.rst
+++ b/docs/manifests.rst
@@ -31,11 +31,13 @@ For example, the GNOME Dictionary manifest includes:
 
 .. code-block:: json
 
-  "app-id": "org.gnome.Dictionary",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "3.26",
-  "sdk": "org.gnome.Sdk",
-  "command": "gnome-dictionary",
+  {
+    "app-id": "org.gnome.Dictionary",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-dictionary",
+  }
 
 Specifying a runtime and runtime version allows that the runtime that is
 needed by your application to be automatically installed on users' systems.
@@ -80,10 +82,12 @@ be seen in the Dictionary manifest file:
 
 .. code-block:: json
 
+  {
     "finish-args": [
        "--socket=x11",
        "--share=network"
     ],
+  }
 
 As was explained in :doc:`first-build`, these two finishing
 properties give the application access to the X11 display server and
@@ -125,18 +129,20 @@ application itself, and looks like:
 
 .. code-block:: json
 
-  "modules": [
-    {
-      "name": "gnome-dictionary",
-      "sources": [
+  {
+    "modules": [
         {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/gnome-dictionary/3.26/gnome-dictionary-3.26.0.tar.xz",
-          "sha256": "387ff8fbb8091448453fd26dcf0b10053601c662e59581097bc0b54ced52e9ef"
+            "name": "gnome-dictionary",
+            "sources": [
+                {
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/gnome-dictionary/3.26/gnome-dictionary-3.26.0.tar.xz",
+                "sha256": "387ff8fbb8091448453fd26dcf0b10053601c662e59581097bc0b54ced52e9ef"
+                }
+            ]
         }
-      ]
-    }
-  ]
+    ]
+  }
 
 As can be seen, each listed module has a ``name`` (which can be freely
 assigned) and a list of ``sources``. Each source has a ``type``, and available

--- a/docs/sandbox-permissions-reference.rst
+++ b/docs/sandbox-permissions-reference.rst
@@ -57,10 +57,10 @@ also be added:
 .. rubric:: Footnotes
 
 .. [#f1] This is not necessarily required, but without it the X11 shared
-memory extension will not work, which is very bad for X11 performance.
+   memory extension will not work, which is very bad for X11 performance.
 .. [#f2] Giving network access also grants access to all host services
-listening on abstract Unix sockets (due to how network namespaces work),
-and these have no permission checks. This unfortunately affects e.g. the X
-server and the session bus which listens to abstract sockets by default. A
-secure distribution should disable these and just use regular sockets.
+   listening on abstract Unix sockets (due to how network namespaces work),
+   and these have no permission checks. This unfortunately affects e.g. the X
+   server and the session bus which listens to abstract sockets by default. A
+   secure distribution should disable these and just use regular sockets.
 

--- a/docs/sandbox-permissions.rst
+++ b/docs/sandbox-permissions.rst
@@ -118,10 +118,10 @@ As a general rule, Filesystem access should be limited as much as
 possible. This includes using:
 
 - Using portals as an alternative to blanket filesystem access, wherever
-possible.
+  possible.
 - Using read-only access wherever possible, using the ``:ro`` option.
 - If some home directory access is absolutely required, using XDG directory
-access only.
+  access only.
 
 The full list the available filesystem options can be found in the
 :doc:`sandbox-permissions-reference`.

--- a/docs/under-the-hood.rst
+++ b/docs/under-the-hood.rst
@@ -65,7 +65,7 @@ Flatpak utilises a number of pre-existing technologies. These include:
 * The OCI format from the `Open Container Initiative
   <https://www.opencontainers.org/>`_, as a convenient transport format for
   single-file bundles
-* The `OSTree <https://ostree.readthedocs.io/en/latest/>`_ system for
+* The `OSTree <https://ostree.readthedocs.io/en/latest/>`__ system for
   versioning and distributing filesystem trees
 * `Appstream <https://www.freedesktop.org/software/appstream/docs/>`_ metadata,
   to allow Flatpak applications to show up nicely in software center applications


### PR DESCRIPTION
This PR provides the following fixes:

- **Fix indentation in footnote and bullet list**, so texts in new line be correctly considered as part of its footnote/bullet list (this messes strings in translation as well)
- **Fix warning of duplicate explicit target name**, caused by OSTree URL collision
- **Fix json code-block syntax**, so json code blocks are properly displayed with json syntax highlighting  

