### PR TITLE
workflow: add build CI on push/pull_request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build docs
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    env:
+      SPHINXOPTS: --color -q -E --keep-going -W
+    
+    steps:
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -U pip
+          pip install -U -r requirements.txt
+      - run: make -C docs/ html SPHINXOPTS="${SPHINXOPTS}"
+      - name: Upload docs as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: translated-docs
+          path: docs/_build/**/html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
This PR adds a GitHub Actions workflow file `.github/workflows/build.yml` that runs on every `push` and `pull_request` event. 

This workflow will be ran when a member pushes a change to the repository, and also when a pull request is opened, synchronized and reopened<sup>[[1]](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request)</sup>.

What does this workflow do: 1) set up a cache dir between workflow runs, 2) checkout flatpak-docs master branch, 3) install dependencies via pip, 4) build the documentation treating warnings as errors, 5) upload built documentation as artifacts

This PR also adds a badge to README.rst for better monitoring this workflow's status.

[1] https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request