### PR TITLE
Update KDE link in available-runtimes

### DIFF
--- a/docs/available-runtimes.rst
+++ b/docs/available-runtimes.rst
@@ -87,7 +87,7 @@ Frameworks. It is appropriate for any application that makes use of the KDE
 platform and most Qt-based applications.
 
 The KDE runtime is maintained `here
-<https://invent.kde.org/kde/flatpak-kde-runtime>`__.
+<https://invent.kde.org/packaging/flatpak-kde-runtime>`__.
 
 Available KDE runtimes:
 


### PR DESCRIPTION
KDE has changed it's link to the Flatpak Runtime repository, from [`kde/flatpak-kde-runtime`](https://invent.kde.org/kde/flatpak-kde-runtime) to [`packaging/flatpak-kde-runtime`](https://invent.kde.org/packaging/flatpak-kde-runtime).

This pull-request modifies the link to the above to reflect the present repository location.