### PR TITLE
add tmpdir env var export to launch app

### DIFF
--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -215,6 +215,7 @@ a sample wrapper for launching app:
   - type: script
     dest-filename: run.sh
     commands:
+      - export TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID
       - zypak-wrapper.sh /app/main/electron-sample-app "$@"
 
 Build commands


### PR DESCRIPTION
This allows for zypak to share the chromium singleton between instances. This is useful when apps are launched via xdg-open from other flatpaks as normally this would start another instance of the app.