### PR TITLE
Update using-flatpak.rst

### DIFF
--- a/docs/using-flatpak.rst
+++ b/docs/using-flatpak.rst
@@ -97,7 +97,7 @@ Add a remote
 The most convenient way to add a remote is by using a ``.flatpakrepo`` file,
 which includes both the details of the remote and its GPG key::
 
- $ flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+ $ flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
 Here, ``flathub`` is the local name that is given to the remote. The URL
 points to the remote's ``.flatpakrepo`` file. ``--if-not-exists`` stops the


### PR DESCRIPTION
Makes the flathub's URL consistent with the other docs (flatpak.org/setup/<some_supported_OS>)