### PR TITLE
electron.rst: Add section about "build"-block in package.json

### DIFF
--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -242,3 +242,21 @@ on ``$PATH``:
       # Install app wrapper
       - install -Dm755 -t /app/bin/ ../run.sh
 
+Settings in package.json
+------------------------
+
+If the application that you are trying to package contains a ``build`` block in ``package.json`` with instructions for Linux, this can cause ``electron-builder`` to try to fetch additional binaries at build-time (Even if `--dir` option is used). The following example shows a configuration that will try to download AppImage binaries:
+
+.. code-block:: json
+
+  "build": {
+    "linux": {
+      "target": "AppImage",
+    }
+  }
+
+The preferred way of fixing this, is not a patch, but a build-time edit using `jq`:
+
+.. code-block:: bash
+
+  jq '.build.linux.target="dir"' <<<$(<package.json) > package.json

--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -242,10 +242,7 @@ on ``$PATH``:
       # Install app wrapper
       - install -Dm755 -t /app/bin/ ../run.sh
 
-Settings in package.json
-------------------------
-
-If the application that you are trying to package contains a ``build`` block in ``package.json`` with instructions for Linux, this can cause ``electron-builder`` to try to fetch additional binaries at build-time (Even if `--dir` option is used). The following example shows a configuration that will try to download AppImage binaries:
+Note that if the application you are trying to package contains a ``build`` block in ``package.json`` with instructions for Linux, this can cause ``electron-builder`` to try to fetch additional binaries at build-time (Even if `--dir` option is used). The following example shows a configuration that will try to download AppImage binaries:
 
 .. code-block:: json
 
@@ -255,7 +252,7 @@ If the application that you are trying to package contains a ``build`` block in 
     }
   }
 
-The preferred way of fixing this, is not a patch, but a build-time edit using `jq`:
+The preferred way of fixing this, is not a patch, but a build-time edit using ``jq``. The following command will replace ``"target": "AppImage"`` with ``"target": "dir"``:
 
 .. code-block:: bash
 


### PR DESCRIPTION
I spend a few hours trying to figure out why electron-builder was trying to download additional binaries. I think the text could clear up some things about the `--dir` option not always working and what electron-builder interprets in `package.json`