### PR TITLE
Small correction: Bubblewrap doesn't use cgroups

### DIFF
--- a/docs/under-the-hood.rst
+++ b/docs/under-the-hood.rst
@@ -53,7 +53,6 @@ Flatpak utilises a number of pre-existing technologies. These include:
   `Project Atomic <http://www.projectatomic.io/>`_, which lets unprivileged
   users set up and run containers, using kernel features such as:
 
-  * Cgroups
   * Namespaces
   * Bind mounts
   * Seccomp rules


### PR DESCRIPTION
according to https://github.com/containers/bubblewrap/issues/233 and as it's already stated as a feature of systemd