### PR TITLE
Use metainfo.xml instead of appdata.xml

### DIFF
--- a/docs/freedesktop-quick-reference.rst
+++ b/docs/freedesktop-quick-reference.rst
@@ -101,16 +101,13 @@ Software) in order to display metadata about your application, such as a
 description, screenshots, changelogs when updates are available, and
 other miscellaneous things.
 
-Your Appdata file should be prefixed with your application's appid and
-placed in ``/app/share/metainfo/``. You should also use
-``appstream-util validate-relax`` to check your file for errors before
-including it.
-
 Example:
 
 ::
 
     /app/share/metainfo/org.gnome.Dictionary.metainfo.xml
+
+More details can be found at :doc:`conventions`.
 
 If interested, you can read the full spec
 `here <https://www.freedesktop.org/software/appstream/docs/>`__.

--- a/docs/freedesktop-quick-reference.rst
+++ b/docs/freedesktop-quick-reference.rst
@@ -110,7 +110,7 @@ Example:
 
 ::
 
-    /app/share/metainfo/org.gnome.Dictionary.appdata.xml
+    /app/share/metainfo/org.gnome.Dictionary.metainfo.xml
 
 If interested, you can read the full spec
 `here <https://www.freedesktop.org/software/appstream/docs/>`__.

--- a/po/de/LC_MESSAGES/conventions.po
+++ b/po/de/LC_MESSAGES/conventions.po
@@ -142,7 +142,7 @@ msgstr ""
 #: ../../conventions.rst:71
 msgid ""
 "AppData files should be named with the application ID and the "
-"``.appdata.xml`` file extension, and should be placed in "
+"``.metainfo.xml`` file extension, and should be placed in "
 "``/app/share/metainfo/``. For example::"
 msgstr ""
 

--- a/po/de/LC_MESSAGES/elements-of-a-flatpak-app.po
+++ b/po/de/LC_MESSAGES/elements-of-a-flatpak-app.po
@@ -113,8 +113,8 @@ msgid ""
 msgstr "Alle Dateien in dem Exportverzeichnis müssen die Applikations-ID als ihr Präfix besitzen. Zum Beispiel:"
 
 #: ../../elements-of-a-flatpak-app.rst:30
-msgid "``org.gnome.App.appdata.xml``"
-msgstr "``org.gnome.App.appdata.xml``"
+msgid "``org.gnome.App.metainfo.xml``"
+msgstr "``org.gnome.App.metainfo.xml``"
 
 #: ../../elements-of-a-flatpak-app.rst:31
 msgid "``org.gnome.App.desktop``"

--- a/po/es/LC_MESSAGES/conventions.po
+++ b/po/es/LC_MESSAGES/conventions.po
@@ -141,7 +141,7 @@ msgstr ""
 #: ../../conventions.rst:71
 msgid ""
 "AppData files should be named with the application ID and the "
-"``.appdata.xml`` file extension, and should be placed in "
+"``.metainfo.xml`` file extension, and should be placed in "
 "``/app/share/metainfo/``. For example::"
 msgstr ""
 

--- a/po/es/LC_MESSAGES/elements-of-a-flatpak-app.po
+++ b/po/es/LC_MESSAGES/elements-of-a-flatpak-app.po
@@ -85,8 +85,8 @@ msgid "All the files in the export directory must have the application ID as the
 msgstr "Todos los archivos en el directorio de exportación deben tener el ID de la aplicación como prefijo.  Por ejemplo:"
 
 #: ../../elements-of-a-flatpak-app.rst:30
-msgid "``org.gnome.App.appdata.xml``"
-msgstr "``org.gnome.App.appdata.xml``"
+msgid "``org.gnome.App.metainfo.xml``"
+msgstr "``org.gnome.App.metainfo.xml``"
 
 #: ../../elements-of-a-flatpak-app.rst:31
 msgid "``org.gnome.App.desktop``"

--- a/po/fr/LC_MESSAGES/conventions.po
+++ b/po/fr/LC_MESSAGES/conventions.po
@@ -143,7 +143,7 @@ msgstr ""
 #: ../../conventions.rst:71
 msgid ""
 "AppData files should be named with the application ID and the "
-"``.appdata.xml`` file extension, and should be placed in "
+"``.metainfo.xml`` file extension, and should be placed in "
 "``/app/share/metainfo/``. For example::"
 msgstr ""
 

--- a/po/fr/LC_MESSAGES/elements-of-a-flatpak-app.po
+++ b/po/fr/LC_MESSAGES/elements-of-a-flatpak-app.po
@@ -84,8 +84,8 @@ msgid "All the files in the ``/export`` directory must have the application ID a
 msgstr "Tous les fichiers dans le répertoire ``/export`` doivent avoir un identifiant d'application comme préfixe. Par exemple:"
  
 #: ../../elements-of-a-flatpak-app.rst:30
-msgid "``org.gnome.App.appdata.xml``"
-msgstr "``org.gnome.App.appdata.xml``"
+msgid "``org.gnome.App.metainfo.xml``"
+msgstr "``org.gnome.App.metainfo.xml``"
 
 #: ../../elements-of-a-flatpak-app.rst:31
 msgid "``org.gnome.App.desktop``"

--- a/po/ko/LC_MESSAGES/conventions.po
+++ b/po/ko/LC_MESSAGES/conventions.po
@@ -141,7 +141,7 @@ msgstr ""
 #: ../../conventions.rst:71
 msgid ""
 "AppData files should be named with the application ID and the "
-"``.appdata.xml`` file extension, and should be placed in "
+"``.metainfo.xml`` file extension, and should be placed in "
 "``/app/share/metainfo/``. For example::"
 msgstr ""
 

--- a/po/pt-BR/LC_MESSAGES/conventions.po
+++ b/po/pt-BR/LC_MESSAGES/conventions.po
@@ -172,11 +172,11 @@ msgstr ""
 #: ../../conventions.rst:71
 msgid ""
 "AppData files should be named with the application ID and the "
-"``.appdata.xml`` file extension, and should be placed in "
+"``.metainfo.xml`` file extension, and should be placed in "
 "``/app/share/metainfo/``. For example::"
 msgstr ""
 "Os arquivos AppData devem ser nomeados com o ID do aplicativo e a "
-"extensão ``.appdata.xml``, e devem ser colocados em "
+"extensão ``.metainfo.xml``, e devem ser colocados em "
 "``/app/share/metainfo/``. Por exemplo::"
 
 #: ../../conventions.rst:76

--- a/po/ru/LC_MESSAGES/conventions.po
+++ b/po/ru/LC_MESSAGES/conventions.po
@@ -188,11 +188,11 @@ msgstr ""
 #: ../../conventions.rst:71
 msgid ""
 "AppData files should be named with the application ID and the "
-"``.appdata.xml`` file extension, and should be placed in "
+"``.metainfo.xml`` file extension, and should be placed in "
 "``/app/share/metainfo/``. For example::"
 msgstr ""
 "Файлы AppData должны быть названы с идентификатором приложения и "
-"расширением файла ``.appdata.xml`` и должны быть помещены в "
+"расширением файла ``.metainfo.xml`` и должны быть помещены в "
 "``/app/share/metainfo/``. Например::"
 
 #: ../../conventions.rst:76

--- a/po/zh_CN/LC_MESSAGES/conventions.po
+++ b/po/zh_CN/LC_MESSAGES/conventions.po
@@ -155,10 +155,10 @@ msgstr ""
 #: ../../conventions.rst:71
 msgid ""
 "AppData files should be named with the application ID and the "
-"``.appdata.xml`` file extension, and should be placed in "
+"``.metainfo.xml`` file extension, and should be placed in "
 "``/app/share/metainfo/``. For example::"
 msgstr ""
-"AppData文件应该以应用的ID命名，并以  ``.appdata.xml``  为文件扩展名，应该放在  "
+"AppData文件应该以应用的ID命名，并以  ``.metainfo.xml``  为文件扩展名，应该放在  "
 "``/app/share/metainfo/``  。举个例子::"
 
 #: ../../conventions.rst:76


### PR DESCRIPTION
- According to https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html, `appdata.xml` is permitted for legacy compatibility.
- Remove appdata duplication and point to conventions