### PR TITLE
Migrate html_context.css_files to html_css_files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,13 +88,11 @@ gettext_compact = False
 #
 html_theme = 'sphinx_rtd_theme'
 
-html_context = {
-    'css_files': [
-        '_static/dark.css',
-        '_static/theme_overrides.css', #GNOME specific overrides
-        'https://fonts.googleapis.com/css?family=Overpass:400,600,700|Source+Sans+Pro:400,400i,700,700i&display=swap&subset=latin-ext', # Web fonts
-        ],
-    }
+html_css_files = [
+    'dark.css',
+    'theme_overrides.css', #GNOME specific overrides
+    'https://fonts.googleapis.com/css?family=Overpass:400,600,700|Source+Sans+Pro:400,400i,700,700i&display=swap&subset=latin-ext', # Web fonts
+]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The use of html_context = {'css_files': []} replaces stylesheets provided by default (pygments.css and css/theme.css), which causes the generated documentation to be unformatted due to incomplete CSS specification.

There's recomendation of using app.add_stylesheet('file.css'), but it is deprecated since 1.8.0, was going to removed in Sphinx 4.0 and then it was postponed to Sphinx 6.0.

Now, html_css_files = [] was added in 1.8.0 to append CSS files, and will fix badly formatted docs by including flatpak-docs stylesheets to the default CSS stylesheets.

Closes: #361