### PR TITLE
Improve CI

### DIFF
--- a/.github/matchers/sphinx-linkcheck-warn.json
+++ b/.github/matchers/sphinx-linkcheck-warn.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "sphinx-warn",
+      "pattern": [
+        {
+          "file": 1,
+          "line": 2,
+          "message": 3,
+          "regexp": "^([^:]*):(\\d+|None): \\[redirected permanently\\] (.*)$"
+        }
+      ],
+      "severity": "warning"
+    }
+  ]
+}
+

--- a/.github/matchers/sphinx-linkcheck.json
+++ b/.github/matchers/sphinx-linkcheck.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "sphinx",
+      "pattern": [
+        {
+          "file": 1,
+          "line": 2,
+          "message": 3,
+          "regexp": "^([^:]*):(\\d+|None): \\[broken\\] (.*)$"
+        }
+      ]
+    }
+  ]
+}
+

--- a/.github/matchers/sphinx.json
+++ b/.github/matchers/sphinx.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "sphinx",
+      "pattern": [
+        {
+          "file": 1,
+          "line": 2,
+          "message": 3,
+          "regexp": "^Error: ([^:]*):(\\d+): (.*)$"
+        }
+      ]
+    }
+  ]
+}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,31 +2,32 @@ name: Build docs
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:
   build:
     name: Build documentation
     runs-on: ubuntu-latest
-    env:
-      SPHINXOPTS: --color -q -E --keep-going -W
-
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'
-          cache-dependency-path: 'requirements.txt'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
         run: |
           python3 -m pip install -U pip
           pip install -U -r requirements.txt
-      - run: make -C docs/ html SPHINXOPTS="${SPHINXOPTS}"
+      - name: Sphinx build
+        run: |
+          echo "::add-matcher::.github/matchers/sphinx.json"
+          make -C docs/ html SPHINXOPTS="${SPHINXOPTS}"
+          echo "::remove-matcher owner=sphinx::"
+        env:
+          SPHINXOPTS: -n -W -a --keep-going
       - name: Upload docs as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: translated-docs
+          name: docs
           path: docs/_build/**/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,36 @@ jobs:
         with:
           name: docs
           path: docs/_build/**/html
+
+  linkcheck:
+    name: Linkcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install -U pip
+          pip install -U -r requirements.txt
+      - name: Sphinx linkcheck
+        run: |
+          make -C docs/ linkcheck SPHINXOPTS="${SPHINXOPTS}"
+        env:
+          SPHINXOPTS: -n -W -a --keep-going
+      - name: Sphinx linkcheck collect
+        if: always()
+        run: |
+          echo "::add-matcher::.github/matchers/sphinx-linkcheck.json"
+          echo "::add-matcher::.github/matchers/sphinx-linkcheck-warn.json"
+          sed 's@^@docs/@' docs/_build/linkcheck/output.txt
+          echo "::remove-matcher owner=sphinx::"
+          echo "::remove-matcher owner=sphinx-warn::"
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Linkcheck report
+          path: docs/_build/linkcheck/output.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Upload docs as artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: docs
+          name: Documentation
           path: docs/_build/**/html
 
   linkcheck:
@@ -63,4 +63,4 @@ jobs:
         if: always()
         with:
           name: Linkcheck report
-          path: docs/_build/linkcheck/output.txt
+          path: docs/_build/**/linkcheck/output.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Build docs
+name: Docs
 
 on:
   push:


### PR DESCRIPTION
- Tweak SPHINXOPTS removing quiet (`-q`) and enabling nit-picky mode (`-n`) and always write output files (`-a`); see [sphinx-build man page](https://www.sphinx-doc.org/en/master/man/sphinx-build.html)
- Add Sphinx matchers to create annotations of warnings and errors generated in the workflow run
- Add linkcheck job to warn about redirected links (which would be good to fix) and err on broken links (which must be fixed)
- Rename workflow filename build -> docs (it also check links, so "build" doesn't say it all), rename artifact filename
- Set permission to read-only, to improve security denying any malicious write attempt in the workflow run