### PR TITLE
Fix link to SearchProvider in GNOME docs

### DIFF
--- a/docs/desktop-integration.rst
+++ b/docs/desktop-integration.rst
@@ -80,7 +80,7 @@ System search
 
 GNOME-based distributions, like CentOS, Fedora, Red Hat Enterprise Linux and
 Ubuntu, provide the option to integrate with system search, by providing a
-`search provider <https://developer.gnome.org/SearchProvider/>`_. This allows
+`search provider <https://developer-old.gnome.org/SearchProvider/>`_. This allows
 application-provided search results to appear in the Activities Overview.
 
 Window controls


### PR DESCRIPTION
https://developer.gnome.org was rewritten with new documentation, so https://developer.gnome.org/SerchProvider doesn't exists and is redirected to the home page. While the page itself should be updated, this proposal works around the issue by changing the URL to point to the old docs in https://developer-old.gnome.org