### PR TITLE
Add l10n workflow to build translated docs

### DIFF
--- a/.github/workflows/L10n.yml
+++ b/.github/workflows/L10n.yml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'po/'
+
+jobs:
+  get-langs-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      languages: ${{ steps.languages.outputs.languages }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: languages
+        shell: bash
+        run: |
+          content="$(find . -mindepth 1 -maxdepth 1 -type d -printf '"%P"\n' | sort | tr '\n' ',' | sed 's|,$||')"
+          echo "languages=[$content]" >> $GITHUB_OUTPUT
+        working-directory: po
+
+  # GitHub Actions editor complains "array was expected but string was found", and it is OK
+  build-translated-docs:
+    needs: [get-langs-changed]
+    strategy:
+      max-parallel: 2
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(needs.get-langs-changed.outputs.languages) }}
+    uses: ./.github/workflows/docs.yml
+    with:
+      language: ${{ matrix.language }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,13 @@ name: Docs
 on:
   push:
   pull_request:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      language:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -25,6 +32,7 @@ jobs:
       - name: Sphinx build
         run: |
           echo "::add-matcher::.github/matchers/sphinx.json"
+          test -n "${{ inputs.language }}" && SPHINXOPTS+=" -D language=${{ inputs.language }}"
           make -C docs/ html SPHINXOPTS="${SPHINXOPTS}"
           echo "::remove-matcher owner=sphinx::"
         env:
@@ -51,6 +59,7 @@ jobs:
           pip install -U -r requirements.txt
       - name: Sphinx linkcheck
         run: |
+          test -n "${{ inputs.language }}" && SPHINXOPTS+=" -D language=${{ inputs.language }}"
           make -C docs/ linkcheck SPHINXOPTS="${SPHINXOPTS}"
         env:
           SPHINXOPTS: -n -W -a --keep-going


### PR DESCRIPTION
The idea is to generate translated documentation and to check translation links whenever translation files is changed. This is in a draft state, and is set to build every language, which is not idea. I have to figure out how to check changed files and only trigger build of the languages with file changes.

See [this example](https://github.com/rffontenelle/flatpak-docs/actions/runs/3374610767) of workflow run.

This is particularly useful for pull request to pop up errors for the translator.