### PR TITLE
 Document graphics driver extensions

### DIFF
--- a/docs/graphics-drivers.rst
+++ b/docs/graphics-drivers.rst
@@ -1,0 +1,2 @@
+How graphics drivers work in Flatpak
+====================================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,4 +27,5 @@ Contents
    publishing
    desktop-integration
    tips-and-tricks
+   graphics-drivers
    reference


### PR DESCRIPTION
Closes https://github.com/flatpak/flatpak-docs/issues/381

I plan to base this off of @TingPing's article over at https://blog.tingping.se/2018/08/26/flatpak-host-extensions.html, and make some use of the mesa-git flatpak extension: https://gitlab.com/freedesktop-sdk/mesa-git-extension

This is a pretty barebones MR right now, so it might be nonfunctional; I'll sort it out later.