### PR TITLE
Fix GitHub's language detection for the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+docs/** -linguist-documentation
+docs/**/*.rst linguist-detectable
+docs/**/*.html linguist-generated


### PR DESCRIPTION
These changes promote `docs/` directory as "source" code of this repo, especially `*.rst` files. As a result, GitHub will see reStructuredText as the main language:
![image](https://github.com/flatpak/flatpak-docs/assets/25753618/b5c680fd-ab6e-4a9d-af96-481e79ae39d3)

Resolves #403.