### PR TITLE
Clarification and a typo in sandbox-permissions-reference.rst

### DIFF
--- a/docs/sandbox-permissions-reference.rst
+++ b/docs/sandbox-permissions-reference.rst
@@ -30,15 +30,15 @@ complete list can be viewed using ``flatpak build-finish --help``.
 Filesystem permissions
 ----------------------
 
-Each of the following permissions configure filesystem access, and should
+Each of the following permissions configures filesystem access, and should
 be added to ``--filesystem=``:
 
 ====================  ===========================================
 ``host``              Access all files [#f3]_
 ``host-etc``          Access all files in /etc
 ``home``              Access the home directory
-``/some/dir``         Access an arbitrary path
-``~/some/dir``        Access an arbitrary path relative to the home directory
+``/some/dir``         Access an arbitrary directory
+``~/some/dir``        Access an arbitrary directory relative to the home directory
 ``xdg-desktop``       Access the XDG desktop directory
 ``xdg-documents``     Access the XDG documents directory
 ``xdg-download``      Access the XDG download directory


### PR DESCRIPTION
A brief test seemed to show that flatpak filesystem permissions don't permit access to arbitrary files - only directories. The example helps guess this rule but this change in wording might make this more clear.