### PR TITLE
Add locale and version to opg site url

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,4 +173,4 @@ texinfo_documents = [
 
 # -- Options for OpenGraph ---------------------------------------------------
 
-ogp_site_url = 'https://docs.flatpak.org/'
+ogp_site_url = 'https://docs.flatpak.org/en/latest'


### PR DESCRIPTION
This is needed, as the image folder for the social images would be expected in the wrong path.

Hopefully the last missing piece