### PR TITLE
Document additions in Electron BaseApp

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,6 +149,13 @@ latex_documents = [
      'Flatpak Team', 'manual'),
 ]
 
+# Ignore link anchors on these sites
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_anchors_ignore_for_url
+linkcheck_anchors_ignore_for_url = [
+    r'https://github\.com/.*',
+    r'https://gitlab\.com/.*',
+    r'https://hg\.mozilla\.org/.*'
+]
 
 # -- Options for manual page output ---------------------------------------
 


### PR DESCRIPTION
This documents the new `patch-desktop-filename `script in the Electron BaseApp introduced in flathub/org.electronjs.Electron2.BaseApp#56. It also describes how to make the UnityLauncherAPI work.

Fell free to correct my wording, as English is not my native language.