### PR TITLE
Update sandbox-permissions-reference.rst

### DIFF
--- a/docs/sandbox-permissions-reference.rst
+++ b/docs/sandbox-permissions-reference.rst
@@ -37,8 +37,9 @@ be added to ``--filesystem=``:
 ``host``              Access all files [#f3]_
 ``host-etc``          Access all files in /etc
 ``home``              Access the home directory
-``/some/dir``         Access an arbitrary path [#f4]_
+``/some/dir``         Access an arbitrary path [#f4]_ [#f5]_
 ``~/some/dir``        Access an arbitrary path relative to the home directory
+                      [#f5]_
 ``xdg-desktop``       Access the XDG desktop directory                          ``$XDG_DESKTOP_DIR`` or ``$HOME/Desktop``
 ``xdg-documents``     Access the XDG documents directory                        ``$XDG_DOCUMENTS_DIR`` or ``$HOME/Documents``
 ``xdg-download``      Access the XDG download directory                         ``$XDG_DOWNLOAD_DIR`` or ``$HOME/Downloads``
@@ -47,9 +48,9 @@ be added to ``--filesystem=``:
 ``xdg-public-share``  Access the XDG public directory                           ``$XDG_PUBLICSHARE_DIR`` or ``$HOME/Public``
 ``xdg-videos``        Access the XDG videos directory                           ``$XDG_VIDEOS_DIR`` or ``$HOME/Videos``
 ``xdg-templates``     Access the XDG templates directory                        ``$XDG_TEMPLATES_DIR`` or ``$HOME/Templates``
-``xdg-config``        Access the XDG config directory [#f5]_                    ``$XDG_CONFIG_HOME`` or ``$HOME/.config``
-``xdg-cache``         Access the XDG cache directory  [#f5]_                    ``$XDG_CACHE_HOME`` or ``$HOME/.cache``
-``xdg-data``          Access the XDG data directory   [#f5]_                    ``$XDG_DATA_HOME`` or ``$HOME/.local/share``
+``xdg-config``        Access the XDG config directory [#f6]_                    ``$XDG_CONFIG_HOME`` or ``$HOME/.config``
+``xdg-cache``         Access the XDG cache directory  [#f6]_                    ``$XDG_CACHE_HOME`` or ``$HOME/.cache``
+``xdg-data``          Access the XDG data directory   [#f6]_                    ``$XDG_DATA_HOME`` or ``$HOME/.local/share``
 ``xdg-run/path``      Access subdirectories of the XDG runtime directory        ``$XDG_RUNTIME_DIR/path`` (``/run/user/$UID/path``)
 ====================  ========================================================  ===================================================
 
@@ -72,7 +73,8 @@ also be added:
    secure distribution should disable these and just use regular sockets.
 .. [#f3] Except for the blacklisted paths mentioned in :doc:`sandbox-permissions`.
 .. [#f4] Except ``/app, /dev, /etc, /lib, /lib32, /lib64, /proc, /root, /run/flatpak, /run/host, /sbin, /usr``
-.. [#f5] ``xdg-{cache, config, data}`` binds mount the paths from host to the per-app sandbox directory.
+.. [#f5] The arbitrary path includes all its subfolders and subfiles if any.
+.. [#f6] ``xdg-{cache, config, data}`` binds mount the paths from host to the per-app sandbox directory.
    Inside the sandbox ``$XDG_CACHE_HOME, $XDG_CONFIG_HOME and $XDG_DATA_HOME`` is set to
    ``$HOME/.var/app/<app-id>/{cache, config, data}``. So this permission is not needed
    unless access to the host directory, bind mounted to


### PR DESCRIPTION
This proposed patch resolved this challenge at https://github.com/tchx84/Flatseal/issues/656#issuecomment-1935237694

About clarifying for newcomers, like me, that Flatseal "Other folders" awesome feature for arbitrary path includes all its subfolders and subfiles if any. In other words, an arbitrary path does not just include one folder or one file. For example, "/some/dir" includes access to "/some/dir/subdir" and so on.

I added one footnote. And adapted the links to the footnotes accordingly.