### PR TITLE
conf: Label sections automatically

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,10 @@
 extensions = [
     'sphinxext.opengraph',
     'sphinx_copybutton',
+    'sphinx.ext.autosectionlabel'
 ]
+
+autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
See https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html

This is useful when referring to arbitrary sections in a different document.

`autosectionlabel_prefix_document` is used to add a file prefix to each label and resolve duplicate label warnings as labels are global.