### PR TITLE
sandbox-permissions: Document the device fallback mechanism

### DIFF
--- a/docs/sandbox-permissions.rst
+++ b/docs/sandbox-permissions.rst
@@ -241,8 +241,73 @@ You can provide the following device permissions:
 While not ideal, ``--device=all`` can be used to access devices like
 generic USB or webcams.
 
-Using newer permissions like ``input`` on older versions of Flatpak
-will have no effect, or fail on the command-line.
+Newer permissions like ``input``, are meant to avoid using ``all`` but
+they will not work on older versions of Flatpak. Since not all
+distributions or users might be running the latest version of Flatpak
+supporting this feature, it is necessary to remain compatible with
+older versions.
+
+Starting with Flatpak 1.16, there is a device fallback mechanism. The
+device fallback mechanism is meant to specify that a certain device
+permission is to be used with a fallback, and therefore, if Flatpak
+knows about it, it can tighten device access as intended and ignore
+the fallback.
+
+Packagers should take great care in considering device permissions and
+use the fallback mechanism when available.
+
+For example in the case where input device access is needed you could
+specify:
+
+.. code-block::
+
+   --device=input
+
+.. warning::
+
+   On the command line, with Flatpak < 1.15.6, you will get an
+   error. In the metadata, it will be ignored making the package not
+   function as intended and offer a poor user experience.
+
+The solution is to use a fallback.
+
+Fallback gets specified with the ``--device`` option like for device
+permissions. It starts with ``fallback:`` and then lists the
+permission, followed by the fallback, separated by a comma. In most
+case the fallback will be ``all`` as there is currently no overlap
+otherwise.
+
+The generic syntax is:
+
+.. code-block::
+
+   --device=fallback:DEVICE_PERMISSION,FALLBACK_PERMISSION
+   --device=FALLBACK_PERMISSION
+
+Specifying a fallback permission (second line) is required.
+
+In the example above, the fallback syntax would be as follows:
+
+.. code-block::
+
+  --device=fallback:input,all
+  --device=all
+
+This translates to "grant permission to ``input`` devices if Flatpak
+supports it and ignore ``all``, otherwise fallback to granting ``all``
+device access".
+
+In this case ``all`` is the fallback permission, and ``input`` is the
+device permission.
+
+The key takeaway is that the fallback mechanism will ignore the
+permission of the fallback (``FALLBACK_PERMISSION``) if all the other
+permissions using it as a fallback are available.
+
+Currently ``all`` is the only practical fallback.
+
+Use of a fallback is not necessary for the following permissions:
+``dri``, ``kvm``, ``shm`` and ``all``.
 
 dconf access
 ````````````

--- a/docs/sandbox-permissions.rst
+++ b/docs/sandbox-permissions.rst
@@ -76,7 +76,7 @@ commonly require, and can therefore be freely used:
 
 - ``--allow=bluetooth`` - Allow access to Bluetooth
 - ``--device=dri`` - OpenGL rendering
-- ``--device=input`` - Access to ``/dev/input``
+- ``--device=input`` - Access to ``/dev/input``, since Flatpak 1.15.6.
 - ``--share=ipc`` - share IPC namespace with the host [#f1]_
 - ``--share=network`` - access the network [#f2]_
 - ``--socket=cups`` - Talk to the CUPS printing system
@@ -223,9 +223,26 @@ requested with ``--filesystem`` and are not available with
 
 Device access
 `````````````
+You can provide the following device permissions:
+
+========= ======================================================
+``dri``   Direct Rendering Interface. Necessary for GL.
+``kvm``   Kernel based Virtual Machine ``/dev/kvm``
+``shm``   Shared Memory in ``/dev/shm``.
+``input`` Input devices as exposed in ``/dev/input``. This includes game controllers. Since Flatpak 1.15.6.
+``all``   All devices, including all of the above except ``shm``
+========= ======================================================
+
+.. note::
+
+   ALSA sound devices in ``/dev/snd`` are exposed with the socket
+   permission ``pulseaudio``.
 
 While not ideal, ``--device=all`` can be used to access devices like
-controllers or webcams.
+generic USB or webcams.
+
+Using newer permissions like ``input`` on older versions of Flatpak
+will have no effect, or fail on the command-line.
 
 dconf access
 ````````````


### PR DESCRIPTION
This is the documentation for https://github.com/flatpak/flatpak/pull/5708

Currently draft, should be landed afer the feature.