### PR TITLE
Makefile: Use sphinx-build as the default sphinx command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,10 +3,14 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD  := `sh -c '[ -e /usr/bin/sphinx-build-3 ] && echo sphinx-build-3 || echo sphinx-build'`
+SPHINXBUILD  := sphinx-build
 SPHINXPROJ    = Flatpak
 SOURCEDIR     = .
 BUILDDIR      = _build
+
+ifeq ($(shell command -v $(SPHINXBUILD) 2> /dev/null),)
+SPHINXBUILD := sphinx-build-3
+endif
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
And fallback to `sphinx-build-3` only if it does not exist.

The default build instructions now use a python virtual environment and inside that pip installs `sphinx-build`. Since the `<venv>/bin` is exported as the first item in `$PATH` once activated, we can ensure that `sphinx-build` from venv is used first.

Outside the venv if `sphinx-build` is not found `sphinx-build-3` is tried.

Closes https://github.com/flatpak/flatpak-docs/issues/477