### PR TITLE
sandbox-permissions: Remove MPRIS example

### DIFF
--- a/docs/sandbox-permissions.rst
+++ b/docs/sandbox-permissions.rst
@@ -111,8 +111,7 @@ D-Bus permissions needed.
 
 Applications are automatically granted access to their own namespace. Ownership
 beyond this is typically unnecessary, although there are a small
-number of exceptions, such as using `MPRIS to provide media controls
-<https://www.freedesktop.org/wiki/Specifications/mpris-spec/>`_.
+number of exceptions.
 
 **Talk**
 


### PR DESCRIPTION
The namespace is automatically granted access to regardless, so the example is not valid.