### PR TITLE
electron: Remove recommendation for setting XDG_CURRENT_DESKTOP

### DIFF
--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -24,15 +24,10 @@ While it isn't strictly necessary, you might want to try building and running
 the sample application yourself.
 
 To get setup for the build, download or clone the sample app from GitHub,
-and navigate to the ``/flatpak`` directory in the terminal. You must also
-install the Electron base app and the Node.js SDK extension::
+and navigate to the ``/flatpak`` directory in the terminal. Then
+to build::
 
-  $ flatpak install flathub org.electronjs.Electron2.BaseApp//23.08
-  $ flatpak install flathub org.freedesktop.Sdk.Extension.node18//23.08
-
-Then you can run the build::
-
-  $ flatpak-builder build org.flathub.electron-sample-app.yml --install --force-clean --user
+  $ flatpak-builder build org.flathub.electron-sample-app.yml --install-deps-from=flathub --force-clean --user --install
 
 Finally, the application can be run with::
 

--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -312,7 +312,4 @@ Make setProgressBar and setBadgeCount work
 The `setProgressBar <https://www.electronjs.org/docs/latest/api/browser-window#winsetprogressbarprogress-options>`_ and `setBadgeCount <https://www.electronjs.org/docs/latest/api/app#appsetbadgecountcount-linux-macos>`_ functions allow showing a progress bar and a badge count in the window icon. It is implemented under Linux using the `UnityLauncherAPI <https://wiki.ubuntu.com/Unity/LauncherAPI>`_. This API is not implemented on every desktop environment. A known desktop environment which implements this is KDE.
 It is also implemented by the popular `Dash to Dock <https://micheleg.github.io/dash-to-dock>`_ GNOME extension and `Plank <https://launchpad.net/plank>`_.
 
-To make it work in Flatpak, the app needs to :ref:`use the correct desktop filename <use-correct-desktop-filename>`. The Flatpak also needs the ``--talk-name=com.canonical.Unity`` permission.
-
-Electron checks `checks if it's running on Unity or KDE <https://github.com/electron/electron/blob/fb88375ab4d2161dbf7e958a2a94c7c6d97dc84c/shell/browser/linux/unity_service.cc#L64>`_ before using the UnityLauncherAPI.
-To make this work on other Desktops too, you need to set ``XDG_CURRENT_SESSION=KDE`` and ``XDG_CURRENT_DESKTOP=KDE`` to pretend the app is running on KDE.
+To make it work in Flatpak, the app needs to :ref:`use the correct desktop filename <use-correct-desktop-filename>`. The Flatpak also needs the ``--talk-name=com.canonical.Unity`` permission. Electron versions earlier than v32 checks `checks if it's running on Unity or KDE <https://github.com/electron/electron/blob/fb88375ab4d2161dbf7e958a2a94c7c6d97dc84c/shell/browser/linux/unity_service.cc#L64>`_ before using the UnityLauncherAPI.


### PR DESCRIPTION
Messing with `XDG_CURRENT_DESKTOP` is a bad idea as that env var used to often find the proper trash cli gio/kio etc. And it is also fixed from v32 (unreleased) https://github.com/electron/electron/pull/41211