### PR TITLE
ci: Create draft PRs by action and set PR types

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/update-flatpak-builder-docs.yml
+++ b/.github/workflows/update-flatpak-builder-docs.yml
@@ -49,3 +49,4 @@ jobs:
             Update Flatpak Builder docs from ${{env.OLD_FLATPAK_BUILDER_VERSION}} to ${{env.NEW_FLATPAK_BUILDER_VERSION}}
           delete-branch: true
           sign-commits: true
+          draft: always-true

--- a/.github/workflows/update-flatpak-docs.yml
+++ b/.github/workflows/update-flatpak-docs.yml
@@ -49,3 +49,4 @@ jobs:
             Update Flatpak docs from ${{env.OLD_FLATPAK_VERSION}} to ${{env.NEW_FLATPAK_VERSION}}
           delete-branch: true
           sign-commits: true
+          draft: always-true


### PR DESCRIPTION
This is a workaround because the create-pull-request action uses the repository's GitHub token and cannot trigger further workflow runs.

See https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

opened, edited, synchronize are the default; reopened is for convenience

Add ready_for_review as per the recommendation here https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs