### PR TITLE
Add update-po Makefile target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Create a Python `virtual environment <https://docs.python.org/3/tutorial/venv.ht
 
 Then install the dependencies with **pip**::
 
-  pip install -r requirements.txt sphinx-intl
+  pip install -r requirements.txt
 
 Build the Documentation
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -45,23 +45,18 @@ By default, the document being built is in English. If you want to build
 documents in other languages, such as Chinese, you can use the following
 command::
 
-  sphinx-build -b html -D language=zh_CN docs docs/_build/html/zh_CN
-
-Then you will see the Chinese documentation in the directory
-``docs/_build/html/zh_CN`` .
+  make -C docs html SPHINXOPTS='-D language=zh_CN'
 
 Translate the Documentation
 ---------------------------
 
 You can open a pull request adding a new language.
 
-Maintainers can generate the ``.pot`` files by running::
+Maintainers can generate the template files (``.pot``), update the translation
+files (``.po``) and remove obsolete translation files (i.e. a matching ``.pot``
+file no longer exists) by running::
 
-  make -C docs gettext
-
-To update ``.po`` files run::
-
-  sphinx-intl update -p docs/_build/gettext -d po
+  make -C docs update-po
 
 Audience
 --------

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -16,7 +16,19 @@ endif
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+update-po:
+	@$(SPHINXBUILD) -M gettext "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@sphinx-intl update -p "$(BUILDDIR)/gettext" -d $(SOURCEDIR)/../po
+	@potfiles=$$(find $(BUILDDIR)/gettext -name '*.pot' | sed 's|.*/||'); \
+	pofiles=$$(find ../po -name '*.po' | sort -u); \
+	for po in $$pofiles; do \
+	  name=$$(echo $$po | sed 's|.*/LC_MESSAGES/||'); \
+	  if ! [[ $$potfiles =~ $${name}t ]]; then \
+	    rm $$po; \
+	  fi; \
+	done
+
+.PHONY: help Makefile update-po
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ furo
 matplotlib
 sphinxext-opengraph
 sphinx-copybutton
+sphinx-intl


### PR DESCRIPTION
This allows to run `make update-po` to 1) generate POT files, 2) update all PO files using the newly generated POT files, 3) remove obsolete PO files that might still be in the PO file.

Also updates the README with the new command, besides using `make` to build translated docs.