### PR TITLE
Fix issues reported by linkcheck

### DIFF
--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -568,7 +568,7 @@ The following extensions utilise the above two extension points::
   org.freedesktop.Platform.GL32.nvidia-${DRIVER_VERSION}
 
 - org.freedesktop.Platform.VulkanLayer - Extension point for
-  `Vulkan layers <https://github.com/KhronosGroup/Vulkan-Guide/blob/master/chapters/layers.md>`_.
+  `Vulkan layers <https://github.com/KhronosGroup/Vulkan-Guide/blob/main/chapters/layers.md>`_.
   Developers can provide extensions using this extension point
   and the user needs to install those extensions to have them available.
 - org.freedesktop.Platform.GStreamer - Extension point for GStreamer

--- a/docs/flatpak-devel.rst
+++ b/docs/flatpak-devel.rst
@@ -365,7 +365,7 @@ desktop file to fix the window class.
 Additional tools
 ----------------
 
-- `Electron Builder <https://www.electron.build/configuration/flatpak.html>`_
+- `Electron Builder <https://www.electron.build/flatpak.html>`_
   supports exporting single file Flatpak bundles. Please also see the
   Electron application packaging guide :doc:`electron`.
 


### PR DESCRIPTION
See [the log](https://github.com/flatpak/flatpak-docs/actions/runs/11061706291/job/30734825416?pr=529) of linkcheck job. Specifically:

> (       extension: line  570) redirect  https://github.com/KhronosGroup/Vulkan-Guide/blob/master/chapters/layers.md - with Found to https://github.com/KhronosGroup/Vulkan-Guide/blob/main/chapters/layers.md
> (   flatpak-devel: line  368) broken    https://www.electron.build/configuration/flatpak.html - 404 Client Error: Not Found for url: https://www.electron.build/configuration/flatpak.html

