### PR TITLE
Correct portals.rst

### DIFF
--- a/docs/portals.rst
+++ b/docs/portals.rst
@@ -31,6 +31,5 @@ hints for what Qt or KDE applications should do to benefit from this.
 - Use ``QDesktopServices::openUrl(const QUrl &url)`` or ``KIO::OpenUrlJob`` to
   open URIs or send an email when using ``mailto`` URL
 - Use ``QFileDialog`` class to open files and, as of Qt ``5.18.90``, directories. Avoid using
-  ``QFileDialog::DontUseNativeDialog``. Note that portals cannot currently
-  give access to directories on the host filesystem
+  ``QFileDialog::DontUseNativeDialog``.
 - Use ``KNotification::notify()`` to show notification


### PR DESCRIPTION
apparently this contradicting sentence got overlooked in https://github.com/flatpak/flatpak-docs/commit/b18084c9dcf97d9d8a119887708db70a46cc193f