### PR TITLE
Polish introduction.rst

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -31,7 +31,7 @@ can be open source or proprietary (although some distribution services, like
 `Flathub <https://flathub.org/>`_, can have restrictions in this respect).
 
 Flatpak's only technical requirements are that applications follow a
-few Freedesktop standards to enable desktop integration
+small number of Freedesktop standards to enable desktop integration
 (see :doc:`conventions`).
 
 Issues with the current packaging model

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -119,7 +119,7 @@ cases:
   For example, Flatpak won't allow spawning sub-namespaces
   in the sandbox.
 - Kernel modules or drivers are non-application packages and won't work
-  inside Flatpak.
+  as a Flatpak.
 
 In general, if the sandbox prohibits an application's core functionality
 or becomes too inconvenient or obtrusive, Flatpak may not be

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -41,7 +41,7 @@ Issues with current model of packaging
 Understanding the problems with the current model
 of packaging applications helps explain why Flatpak exists:
 
-- **Duplicated work packaging apps**: many Linux distributions have their own
+- **Fragmentation and duplicated work**: each Linux distribution has their own
   package manager and package format that are incompatible with each other. This leads to a lot of fragmentation and duplicated work since the same application needs to be packaged multiple times for various distributions.
   duplicated work, with different maintainers packaging the same application
   for various distributions. Otherwise, developers either need to learn the format of

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -8,16 +8,14 @@ working on the Linux desktop and is run as an independent open source project.
 Terminology
 -----------
 
-- Flatpak: a system for building, distributing, and running sandboxed desktop
-  applications on Linux.
+- Flatpak: a system for building, distributing, and running sandboxed desktop applications on Linux.
 - Flatpak application: an application installed via the ``flatpak`` command or through a
   graphical interface, such as GNOME Software or KDE Discover.
 - Runtime: also called platform, an integrated environment providing basic
   utilities needed for a Flatpak application to work.
 - BaseApp: an integrated set of additional libraries and frameworks, such as Electron, for Flatpak
   applications that need more than just the basic runtime.
-- Flatpak bundle: a single-file export format containing a Flatpak appplication or
-  runtime.
+- Flatpak bundle: a single-file export format containing a Flatpak appplication or runtime.
 
 Target audience
 ---------------
@@ -32,8 +30,9 @@ other operating systems as well as those that are Linux-specific. Applications
 can be open source or proprietary (although some distribution services, like
 `Flathub <https://flathub.org/>`_, can have restrictions in this respect).
 
-Flatpak's only technical requirements are that applications follow a few
-Freedesktop standards to enable desktop integration (see :doc:`conventions`).
+Flatpak's only technical requirements are that applications follow a
+few Freedesktop standards to enable desktop integration
+(see :doc:`conventions`).
 
 Issues with current model of packaging
 --------------------------------------
@@ -41,22 +40,22 @@ Issues with current model of packaging
 It is important to understand the problems with the current model
 of packaging applications to understand the existence of Flatpak:
 
-- **Fragmentation and duplicated work**: each Linux distribution has their own
-  package managers and package formats that are incompatible with each other. This leads to a lot of fragmentation and duplicated work since the same application needs to be packaged multiple times for various distributions.
-  duplicated work, with different maintainers packaging the same application
-  for various distributions. Otherwise, developers either need to learn the format of
-  every distribution or support only a few. This makes
+- **Fragmentation and duplicated work**: each Linux distribution has their own package
+  managers and package formats that are incompatible with each other.
+  This leads to a lot of fragmentation and duplicated work since the same application
+  needs to be packaged multiple times for various distributions. Furthermore, developers
+  either need to learn the format of every distribution or support only a few. This makes
   the Linux desktop a difficult platform for software vendors to target.
-- **Limited to apps that are packaged**: not every application is packaged for every Linux distribution. If an application isn't packaged for a specific distribution, users
-are left with limited and unreliable options, often technical in nature.
-- **Limited to distributions that have the apps**: users are limited only to
-  the distributions that have all the necessary applications for their workflow.
+- **Limited to apps that are packaged**: not every application is packaged for
+  every Linux distribution. If an application isn't packaged for a specific
+  distribution, users are left with limited and unreliable options, often technical in nature.
+- **Limited to distributions that have the apps**: users are limited to only the
+  distributions that have all the necessary applications for their workflow.
 - **Hard to innovate in OS space**: distribution maintainers spend a huge amount of
-time and effort in packaging rather than focusing on improving their distributions.
-- **Old and outdated packages**: LTS distributions often have very old
-  versions of applications packaged. This complicates bug
-  reproducibility or leads to support requests for bugs that have been fixed
-  upstream in newer versions.
+  time and effort in packaging rather than focusing on improving their distributions.
+- **Old and outdated packages**: LTS distributions often have very old versions of applications
+  packaged. This complicates bug reproducibility or leads to support
+  requests for bugs that have been fixed upstream in newer versions.
 
 Flatpak addresses these issues by enabling developers to distribute
 applications from one source and target the entire Linux desktop.
@@ -68,50 +67,66 @@ Flatpak offers major advantages over most system package managers:
 
 - **Universality**: Flatpak allows applications to be installed and run on virtually any Linux
   distribution, including non-GNU distributions, systemd-free distributions,
-  immutable distributions and various architectures without requiring
-  the developer to have access to the relevant hardware.
+  immutable distributions and various architectures without requiring the
+  developer to have access to the relevant hardware.
 - **Space for innovation**: Flatpak allows distribution maintainers to focus on
   innovating their distribution without being burdened by packaging concerns.
-- **Stability**: breakages in Flatpak applications do not affect the system,
+- **Stability**: breakages in Flatpak applications do not affect the system
   since they run in isolated environments.
 - **Rootless install**: Flatpak does not require elevated privileges to install
   applications or runtimes.
-- **Sandboxed applications**: one of Flatpak's main goals is to increase the security of desktop systems. This is achieved by isolating applications from one another and limiting their access to the host environment.
+- **Sandboxed applications**: one of Flatpak's main goals is to increase the security of desktop
+  systems. This is achieved by isolating applications from one another and limiting their
+  access to the host environment.
 
 Flatpak also offers advantages over other universal approaches to Linux application distribution:
 
-- **Decentralized by design**: Flatpak offers decentralized hosting and distribution, allowing developers or
-  downstreams to host their own applications and application repositories.
-- **Desktop integration**: Flatpak offers native integration with the many Linux desktop environments, allowing users to easily browse, install, run, and manage Flatpak
+- **Decentralized by design**: Flatpak offers decentralized hosting and distribution,
+  allowing developers or downstreams to host their own applications and
+  application repositories.
+- **Desktop integration**: Flatpak offers native integration with many Linux desktop environments, allowing
+  users to easily browse, install, run, and manage Flatpak applications.
+- **Space efficiency**: Flatpak saves storage by deduplicating libraries and other files used by multiple
   applications.
-- **Space efficiency**: Flatpak saves storage by deduplicating libraries and
-  other files used by multiple applications.
 - **Delta updates**: only changed files are downloaded during updates.
 
 Other benefits for developers include:
 
-- **Forward-compatibility**: the same Flatpak application can run on different versions of a distribution, including unreleased versions, without needing any changes.
-- **Bundling**: this allows application developers to ship almost any dependency or library as part of their applications, giving them complete control over their applications.
-- **Consistent application environments**: Flatpak provides a consistent and identical application runtime environment across devices and distributions. This makes bug identification and testing easier.
-- **Branches**: this allows application developers to distribute multiple branches of an applications (e.g. ``stable``, ``beta``, etc.) while retaining the same name.
-- **Maintained platforms**: Flatpak runtimes contains a collection of common dependencies for the applications to use, easing application development and maintenance.
+- **Forward-compatibility**: the same Flatpak application can run on different versions
+  of a distribution, including unreleased versions, without needing any changes.
+- **Bundling**: this allows application developers to ship almost any
+  dependency or library as part of their applications, giving them complete
+  control over their applications.
+- **Consistent application environments**: Flatpak provides a consistent and identical
+  application runtime environment across devices and distributions. This makes
+  bug identification and testing easier.
+- **Branches**: this allows application developers to distribute multiple branches of
+  an applications (e.g. ``stable``, ``beta``, etc.) while retaining the same name.
+- **Maintained platforms**: Flatpak runtimes contains a collection
+  of common dependencies for the applications to use, easing
+  application development and maintenance.
 
-In general, Flatpak is best suited for desktop applications. While command-line
-applications also work, Flatpak may not be suitable in some cases:
 
-- The application needs to elevate privileges using ``su``, ``sudo``, ``pkexec``, etc.
-  Flatpak cannot run SUID binaries inside the sandbox.
-- The application requires access to ``/proc`` on the host or unfiltered
-  access to processes. This is not allowed as Flatpak has a private ``proc``.
-- The application uses a syscall blocklisted by Flatpak's seccomp filter. For
-  example, Flatpak won't allow spawning sub-namespaces in the sandbox.
+In general, Flatpak is best suited for desktop applications.
+While command-line applications also work, Flatpak may not be suitable in some
+cases:
+
+- The application needs to elevate privileges using ``su``, ``sudo``, ``pkexec``,
+  etc. Flatpak cannot run SUID binaries inside the sandbox.
+- The application requires access to ``/proc`` on the host or unfiltered access
+  to processes. This is not allowed as Flatpak has a private ``proc``.
+- The application uses a syscall blocklisted by Flatpak's seccomp filter.
+  For example, Flatpak won't allow spawning sub-namespaces
+  in the sandbox.
 - Kernel modules or drivers are non-application packages and won't work
   inside a flatpak.
 
-In general, if the sandbox prohibits an application's core functionality or becomes
-too inconvenient or obtrusive, Flatpak may not be the most suitable packaging choice.
+In general, if the sandbox prohibits an application's core functionality
+or becomes too inconvenient or obtrusive, Flatpak may not be
+the most suitable packaging choice.
 
 Flatpak also won't export udev rules or systemd services from the sandbox
-to the host and requires manual configuration after installing the Flatpak package.
+to the host and requires manual configuration after installing the
+Flatpak package.
 
 Information about Flatpak's internals can be found in :doc:`under-the-hood`.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -88,7 +88,7 @@ Flatpak also offers advantages over other universal approaches to Linux applicat
   users to easily browse, install, run, and manage Flatpak applications.
 - **Space efficiency**: Flatpak saves storage by deduplicating libraries and other files used by multiple
   applications.
-- **Delta updates**: only changed files are downloaded during updates.
+- **Delta updates**: only the differences between versions are downloaded during updates.
 
 Other benefits for developers include:
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -15,7 +15,7 @@ Terminology
   utilities needed for a Flatpak application to work.
 - BaseApp: an integrated set of additional libraries and frameworks, such as Electron, for Flatpak
   applications that need more than just the basic runtime.
-- Flatpak bundle: a single-file export format containing a Flatpak appplication or runtime.
+- Flatpak bundle: a single-file export format containing a Flatpak application or runtime.
 
 Target audience
 ---------------
@@ -34,8 +34,8 @@ Flatpak's only technical requirements are that applications follow a
 few Freedesktop standards to enable desktop integration
 (see :doc:`conventions`).
 
-Issues with current model of packaging
---------------------------------------
+Issues with the current model of packaging
+------------------------------------------
 
 It is important to understand the problems with the current model
 of packaging applications to understand the existence of Flatpak:
@@ -88,7 +88,7 @@ Flatpak also offers advantages over other universal approaches to Linux applicat
   users to easily browse, install, run, and manage Flatpak applications.
 - **Space efficiency**: Flatpak saves storage by deduplicating libraries and other files used by multiple
   applications.
-- **Delta updates**: only the differences between versions are downloaded during updates.
+- **Delta updates**: only the differences between versions are downloaded during updates, saving network bandwidth.
 
 Other benefits for developers include:
 
@@ -101,8 +101,8 @@ Other benefits for developers include:
   application runtime environment across devices and distributions. This makes
   bug identification and testing easier.
 - **Branches**: this allows application developers to distribute multiple branches of
-  an applications (e.g. ``stable``, ``beta``, etc.) while retaining the same name.
-- **Maintained platforms**: Flatpak runtimes contains a collection
+  an application (e.g. ``stable``, ``beta``, etc.) while retaining the same name.
+- **Maintained platforms**: Flatpak runtimes contain a collection
   of common dependencies for the applications to use, easing
   application development and maintenance.
 
@@ -119,7 +119,7 @@ cases:
   For example, Flatpak won't allow spawning sub-namespaces
   in the sandbox.
 - Kernel modules or drivers are non-application packages and won't work
-  inside a flatpak.
+  inside Flatpak.
 
 In general, if the sandbox prohibits an application's core functionality
 or becomes too inconvenient or obtrusive, Flatpak may not be

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -34,8 +34,8 @@ Flatpak's only technical requirements are that applications follow a
 few Freedesktop standards to enable desktop integration
 (see :doc:`conventions`).
 
-Issues with the current model of packaging
-------------------------------------------
+Issues with the current packaging model
+---------------------------------------
 
 It is important to understand the problems with the current model
 of packaging applications to understand the existence of Flatpak:
@@ -88,7 +88,7 @@ Flatpak also offers advantages over other universal approaches to Linux applicat
   users to easily browse, install, run, and manage Flatpak applications.
 - **Space efficiency**: Flatpak saves storage by deduplicating libraries and other files used by multiple
   applications.
-- **Delta updates**: only the differences between versions are downloaded during updates, saving network bandwidth.
+- **Delta updates**: only updated data is downloaded during updates, saving network bandwidth.
 
 Other benefits for developers include:
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -3,7 +3,7 @@ Introduction to Flatpak
 
 Flatpak is a framework for distributing desktop applications across various
 Linux distributions. It was created by developers with a long history of
-working on the Linux desktop and is run as an independent open-source project.
+working on the Linux desktop and is run as an independent open source project.
 
 Terminology
 -----------
@@ -29,7 +29,7 @@ or frameworks can be used.
 
 While Flatpak only runs on Linux, it can be used by applications that target
 other operating systems as well as those that are Linux-specific. Applications
-can be open-source or proprietary (although some distribution services, like
+can be open source or proprietary (although some distribution services, like
 `Flathub <https://flathub.org/>`_, can have restrictions in this respect).
 
 Flatpak's only technical requirements are that applications follow a few
@@ -38,11 +38,11 @@ Freedesktop standards to enable desktop integration (see :doc:`conventions`).
 Issues with current model of packaging
 --------------------------------------
 
-Understanding the problems with the current model
-of packaging applications helps explain why Flatpak exists:
+It is important to understand the problems with the current model
+of packaging applications to understand the existence of Flatpak:
 
 - **Fragmentation and duplicated work**: each Linux distribution has their own
-  package manager and package format that are incompatible with each other. This leads to a lot of fragmentation and duplicated work since the same application needs to be packaged multiple times for various distributions.
+  package managers and package formats that are incompatible with each other. This leads to a lot of fragmentation and duplicated work since the same application needs to be packaged multiple times for various distributions.
   duplicated work, with different maintainers packaging the same application
   for various distributions. Otherwise, developers either need to learn the format of
   every distribution or support only a few. This makes
@@ -50,12 +50,12 @@ of packaging applications helps explain why Flatpak exists:
 - **Limited to apps that are packaged**: not every application is packaged for every Linux distribution. If an application isn't packaged for a specific distribution, users
 are left with limited and unreliable options, often technical in nature.
 - **Limited to distributions that have the apps**: users are limited only to
-  the distributions that have the all necessary applications for their workflow.
+  the distributions that have all the necessary applications for their workflow.
 - **Hard to innovate in OS space**: distribution maintainers spend a huge amount of
-time and effort in packaging rather than focusing on improving the distribution.
+time and effort in packaging rather than focusing on improving their distributions.
 - **Old and outdated packages**: LTS distributions often have very old
   versions of applications packaged. This complicates bug
-  reproducibility or leads to support requests for bugs that are fixed
+  reproducibility or leads to support requests for bugs that have been fixed
   upstream in newer versions.
 
 Flatpak addresses these issues by enabling developers to distribute
@@ -80,10 +80,9 @@ Flatpak offers major advantages over most system package managers:
 
 Flatpak also offers advantages over other universal approaches to Linux application distribution:
 
-- **Decentralized by design**: while Flatpak does provide a centralized service for distributing
-  applications, it also offers decentralized hosting and distribution, allowing developers or
+- **Decentralized by design**: Flatpak offers decentralized hosting and distribution, allowing developers or
   downstreams to host their own applications and application repositories.
-- **Desktop integration**: Flatpak offers native integration with the many Linux desktop environments allowing users to easily browse, install, run, and manage Flatpak
+- **Desktop integration**: Flatpak offers native integration with the many Linux desktop environments, allowing users to easily browse, install, run, and manage Flatpak
   applications.
 - **Space efficiency**: Flatpak saves storage by deduplicating libraries and
   other files used by multiple applications.
@@ -92,7 +91,7 @@ Flatpak also offers advantages over other universal approaches to Linux applicat
 Other benefits for developers include:
 
 - **Forward-compatibility**: the same Flatpak application can run on different versions of a distribution, including unreleased versions, without needing any changes.
-- **Bundling**: this allows application developers to ship almost any dependency or library as part of their applications, giving them complete control over their application.
+- **Bundling**: this allows application developers to ship almost any dependency or library as part of their applications, giving them complete control over their applications.
 - **Consistent application environments**: Flatpak provides a consistent and identical application runtime environment across devices and distributions. This makes bug identification and testing easier.
 - **Branches**: this allows application developers to distribute multiple branches of an applications (e.g. ``stable``, ``beta``, etc.) while retaining the same name.
 - **Maintained platforms**: Flatpak runtimes contains a collection of common dependencies for the applications to use, easing application development and maintenance.
@@ -113,6 +112,6 @@ In general, if the sandbox prohibits an application's core functionality or beco
 too inconvenient or obtrusive, Flatpak may not be the most suitable packaging choice.
 
 Flatpak also won't export udev rules or systemd services from the sandbox
-to the host, requiring manual configuration after installing the Flatpak package.
+to the host and requires manual configuration after installing the Flatpak package.
 
 Information about Flatpak's internals can be found in :doc:`under-the-hood`.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,142 +1,131 @@
 Introduction to Flatpak
 =======================
 
-Flatpak is a framework for distributing desktop applications across various Linux
-distributions. It has been created by developers who have a long history of working on the
-Linux desktop, and is run as an independent open source project.
+Flatpak is a framework for distributing desktop applications across various
+Linux distributions. It was created by developers with a long history of
+working on the Linux desktop and is run as an independent open-source project.
 
 Terminology
 -----------
 
-- Flatpak: a system for building, distributing, and running sandboxed desktop applications on Linux.
-- Flatpak application: these are the applications the user installs via the ``flatpak`` command or via a
-  different UI like GNOME Software or KDE Discover.
-- Runtime: also called platforms, these are integrated platforms to provide basic utilities needed for a
-  Flatpak application to work.
-- BaseApp: these are integrated platforms for frameworks like Electron.
-- Flatpak bundle: a specific single-file export format which contains a Flatpak app or runtime.
+- Flatpak: a system for building, distributing, and running sandboxed desktop
+  applications on Linux.
+- Flatpak application: an application installed via the ``flatpak`` command or through a
+  graphical interface, such as GNOME Software or KDE Discover.
+- Runtime: also called platform, an integrated environment providing basic
+  utilities needed for a Flatpak application to work.
+- BaseApp: an integrated set of additional libraries and frameworks, such as Electron, for Flatpak
+  applications that need more than just the basic runtime.
+- Flatpak bundle: a single-file export format containing a Flatpak appplication or
+  runtime.
 
 Target audience
 ---------------
 
-Flatpak can be used by all kinds of desktop applications, and aims to be
-as agnostic as possible regarding how applications are built. There are no
-requirements regarding which programming languages, build tools, toolkits
-or frameworks can be used.
+Flatpak can be used by all kinds of desktop applications and aims to be as
+agnostic as possible in terms of how applications are built. There are no
+requirements regarding the programming languages, build tools, toolkits, or
+frameworks used.
 
 While Flatpak only runs on Linux, it can be used by applications that target
-other operating systems, as well as those that are Linux-specific. Applications
-can be open source or proprietary (although some distribution services, like
+other operating systems as well as those that are Linux-specific. Applications
+can be open-source or proprietary (although some distribution services, like
 `Flathub <https://flathub.org/>`_, can have restrictions in this respect).
 
-The only technical requirements made by Flatpak are that applications follow a
-small number of Freedesktop standards, in order to enable desktop integration
-(see :doc:`conventions`).
+Flatpak's only technical requirements are that applications follow a few
+Freedesktop standards to enable desktop integration (see :doc:`conventions`).
 
-Issues of current model of packaging
-------------------------------------
+Issues with current model of packaging
+--------------------------------------
 
-It is important to understand the problems of the current model
-of packaging applications to understand the existence of Flatpak:
+Understanding the problems with the current model
+of packaging applications helps explain why Flatpak exists:
 
-- **Duplicated work packaging apps**: many Linux distributions come with their own package
-  manager, package format and repository. This requires a lot of maintainers to package the
-  same application in various distributions, or the application developer to learn the
-  language of each format and then package the application in those distributions, or
-  ignore most distributions and package and support a couple of distributions. This makes
+- **Duplicated work packaging apps**: many Linux distributions have their own
+  package manager, package format, and package repository. This leads to a lot of
+  duplicated work, with different maintainers packaging the same application
+  for various distributions. Otherwise, developers either need to learn the format of
+  each distribution or ignore most distributions and support only a few. This makes
   the Linux desktop a difficult platform for software vendors to target.
-- **Limited to apps that are packaged**: not all applications are natively available
-  in every Linux distribution. If an application is not available in a specific
-  distribution, the user will have to rely on manually downloading the archive
-  of the application, extracting it and hoping the application will launch.
-- **Limited to distributions that have the apps**: the user is limited to the
-  number of distributions that have the needed applications for them
-  to properly setup their workflow. This reduces the amount of distributions
-  that can be suitable for a user.
-- **Hard to innovate in OS space**: the maintainers of the distributions have to spend a lot of
-  time packaging applications to make the distribution suitable for the end user, instead of focusing
-  on their end goals. This delays the progress of each distribution.
-- **Old and outdated packages**: LTS distributions often have very old versions of applications
-  packaged natively. Bug reproducibility is hindered by the different environments that applications
-  are run in, and application developers often have little control over how their application is
-  packaged by distributions.
+- **Limited to apps that are packaged**: not every application is natively
+  available in every Linux distribution. If an application is not available in
+  a specific distribution, users must manually download the archive of
+  the application, then extract it and hope the application will launch.
+- **Limited to distributions that have the apps**: users are limited to
+  distributions that have the necessary applications for their workflow.
+  This reduces the number of suitable distributions for a user.
+- **Hard to innovate in OS space**: distribution maintainers spend much of their time
+  packaging applications rather than focus on their end goals. This delays each
+  distribution's progress.
+- **Old and outdated packages**: LTS distributions often have very old
+  versions of applications packaged natively. This complicates bug
+  reproducibility since applications run in different environments, and
+  developers often have little control over how their applications are packaged
+  by distributions.
 
-Flatpak strives to fix the issues listed above, by conveniently enabling developers to distribute
-applications from one source and to target the entire Linux desktop.
+Flatpak addresses these issues by enabling developers to distribute
+applications from one source and target the entire Linux desktop.
 
 Reasons to use Flatpak
 ----------------------
 
-Flatpak has some major advantages over most system package managers:
+Flatpak offers major advantages over most system package managers:
 
 - **Universality**: Flatpak allows applications to be installed and run on virtually any Linux
-  distribution. This includes non-GNU distributions, systemd-free distributions,
-  distributions with a read-only operating system (OS), and various architectures without the
-  developer needing the relevant hardware on hand.
-- **Space for innovations**: Flatpak facilitates distribution maintainers to focus on their goals
-  to innovate their distribution.
-- **Stability**: breakage in a Flatpak application will not risk the system from breaking.
-  This is because Flatpak applications and runtimes are contained to not interfere
-  with the system altogether.
-- **Rootless install**: elevated privileges are not required when installing a Flatpak
-  application or a runtime.
-- **Sandboxed applications**: one of Flatpak's main goals is to increase the security of desktop
-  systems by isolating applications from one another. This is achieved using sandboxing and means
-  that, by default, applications that are run with Flatpak have limited access to the host environment.
+  distribution, including non-GNU distributions, systemd-free distributions,
+  distributions with a read-only operating system (OS), and various architectures without requiring
+  the developer to have access to the relevant hardware.
+- **Space for innovation**: Flatpak allows distribution maintainers to focus on
+  innovating their distribution without being burdened by packaging concerns.
+- **Stability**: breakages in Flatpak applications won't affect the system,
+  since they run in isolated environments.
+- **Rootless install**: Flatpak does not require elevated privileges to install
+  applications or runtimes.
+- **Sandboxed applications**: Flatpak increases security, one of its main goals, by
+  isolating applications from one another and limiting their access to the host environment.
 
-Flatpak has some major advantages over other universal approaches to distributing
-applications on Linux:
+Flatpak also offers advantages over other universal approaches to Linux application distribution:
 
 - **Decentralized by design**: while Flatpak does provide a centralized service for distributing
-  applications, it also allows decentralized hosting and distribution, so that
-  application developers or downstreams can host their own applications and
-  application repositories.
-- **Desktop integration**: Flatpak also offers native integration for the main Linux desktops, so that
-  users can easily browse, install, run and use Flatpak applications through
-  their existing desktop environment and tools.
-- **Space efficiency**: Flatpak deduplicates libraries and other files used by multiple
-  applications to save megabytes or even gigabytes worth of storage depending on
-  the amount of applications installed.
-- **Delta updates**: only changed files are downloaded for updates.
+  applications, it also offers decentralized hosting and distribution, allowing developers or
+  downstreams to host their own applications and application repositories.
+- **Desktop integration**: Flatpak offers native integration with the main Linux desktops,
+  allowing users to easily browse, install, run, and manage Flatpak
+  applications through their existing desktop environment and tools.
+- **Space efficiency**: Flatpak saves storage by deduplicating libraries and
+  other files used by multiple applications.
+- **Delta updates**: only changed files are downloaded during updates.
 
 Other benefits for developers include:
 
-- **Forward-compatibility**: the same Flatpak application can be run on different versions
-  of the same distribution, including versions that haven't been released
-  yet. This doesn't require any changes or management by application developers.
-- **Bundling**: this allows application developers to ship almost any
-  dependency or library as part of their application. This gives complete
-  control over which software is used to build applications.
-- **Consistent application environments**: because these are the same across
-  devices, applications perform as intended. This also makes it easier to
-  identify bugs and to do testing.
-- **Branches**: this allows developers to ship applications from different
-  branches, e.g. ``stable``, ``beta``, etc. while retaining the same name.
-- **Maintained platforms**: called runtimes, these contain collections of
-  dependencies, which can be used by applications, and which can take a lot
-  of the work out of application development.
+- **Forward-compatibility**: the same Flatpak application can run on different versions of
+  the same distribution, including unreleased versions, without changes from the application
+  developer.
+- **Bundling**: developers can ship almost any dependency or library as part of
+  their applications, giving them control over the softwares used to build them.
+- **Consistent application environments**: because application environments are identical across
+devices, applications run as expected; bug identification, as well as testing, is also made easier.
+- **Branches**: developers can distribute applications from different branches
+  (e.g. ``stable``, ``beta``, etc.) while the application name can stay the same.
+- **Maintained platforms**: Flatpak's maintained runtimes contain collections
+  of dependencies for applications to use, easing development.
 
+In general, Flatpak is best suited for desktop applications. While command-line
+applications also work, Flatpak may not be suitable in some cases:
 
-In general Flatpak is best suited for desktop applications and
-while command line applications also work, it may not be suited in some
-cases:
+- The application needs to elevate privileges using ``su``, ``sudo``, ``pkexec``, etc.
+  Flatpak cannot run SUID binaries inside the sandbox.
+- The application requires access to ``/proc`` on the host or unfiltered
+  access to processes. This is not allowed as Flatpak has a private ``proc``.
+- The application uses a syscall blocklisted by Flatpak's seccomp filter. For
+  example, Flatpak won't allow spawning sub-namespaces in the sandbox.
+- Kernel modules or drivers are non-application packages and won't work
+  inside a flatpak.
 
-- Applications needs to elevate priviledges using ``su, sudo, pkexec``
-  etc. Flatpak cannot run in SUID binaries inside the sandbox.
-- Application needs to read ``/proc`` from host or have unfiltered access
-  to processes. This is not allowed as Flatpak has a private proc.
-- Application uses a syscall that is blocklisted by Flatpak's seccomp
-  filter. For example, Flatpak won't allow spawning sub-namespaces
-  in the sandbox.
-- Kernel modules or drivers are non application packages and won't work
-  inside a Flatpak.
-
-In general in cases where the sandbox prohibits the core functionality
-of the application or makes it too inconvenient and/or obtrusive , it is
-not best suited to be packaged with Flatpak.
+In general, if the sandbox prohibits an application's core functionality or becomes
+too inconvenient or obtrusive, Flatpak may not be the most suitable packaging choice.
 
 Flatpak also won't export udev rules or systemd services from the sandbox
-to the host and requires manual configuration after installing the
-flatpak package.
+to the host, requiring manual configuration after installing the Flatpak package.
 
 Information about Flatpak's internals can be found in :doc:`under-the-hood`.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -24,8 +24,8 @@ Target audience
 
 Flatpak can be used by all kinds of desktop applications and aims to be as
 agnostic as possible in terms of how applications are built. There are no
-requirements regarding the programming languages, build tools, toolkits, or
-frameworks used.
+requirements regarding which programming languages, build tools, toolkits
+or frameworks can be used.
 
 While Flatpak only runs on Linux, it can be used by applications that target
 other operating systems as well as those that are Linux-specific. Applications
@@ -42,26 +42,21 @@ Understanding the problems with the current model
 of packaging applications helps explain why Flatpak exists:
 
 - **Duplicated work packaging apps**: many Linux distributions have their own
-  package manager, package format, and package repository. This leads to a lot of
+  package manager and package format that are incompatible with each other. This leads to a lot of fragmentation and duplicated work since the same application needs to be packaged multiple times for various distributions.
   duplicated work, with different maintainers packaging the same application
   for various distributions. Otherwise, developers either need to learn the format of
-  each distribution or ignore most distributions and support only a few. This makes
+  every distribution or support only a few. This makes
   the Linux desktop a difficult platform for software vendors to target.
-- **Limited to apps that are packaged**: not every application is natively
-  available in every Linux distribution. If an application is not available in
-  a specific distribution, users must manually download the archive of
-  the application, then extract it and hope the application will launch.
-- **Limited to distributions that have the apps**: users are limited to
-  distributions that have the necessary applications for their workflow.
-  This reduces the number of suitable distributions for a user.
-- **Hard to innovate in OS space**: distribution maintainers spend much of their time
-  packaging applications rather than focus on their end goals. This delays each
-  distribution's progress.
+- **Limited to apps that are packaged**: not every application is packaged for every Linux distribution. If an application isn't packaged for a specific distribution, users
+are left with limited and unreliable options, often technical in nature.
+- **Limited to distributions that have the apps**: users are limited only to
+  the distributions that have the all necessary applications for their workflow.
+- **Hard to innovate in OS space**: distribution maintainers spend a huge amount of
+time and effort in packaging rather than focusing on improving the distribution.
 - **Old and outdated packages**: LTS distributions often have very old
-  versions of applications packaged natively. This complicates bug
-  reproducibility since applications run in different environments, and
-  developers often have little control over how their applications are packaged
-  by distributions.
+  versions of applications packaged. This complicates bug
+  reproducibility or leads to support requests for bugs that are fixed
+  upstream in newer versions.
 
 Flatpak addresses these issues by enabling developers to distribute
 applications from one source and target the entire Linux desktop.
@@ -73,42 +68,34 @@ Flatpak offers major advantages over most system package managers:
 
 - **Universality**: Flatpak allows applications to be installed and run on virtually any Linux
   distribution, including non-GNU distributions, systemd-free distributions,
-  distributions with a read-only operating system (OS), and various architectures without requiring
+  immutable distributions and various architectures without requiring
   the developer to have access to the relevant hardware.
 - **Space for innovation**: Flatpak allows distribution maintainers to focus on
   innovating their distribution without being burdened by packaging concerns.
-- **Stability**: breakages in Flatpak applications won't affect the system,
+- **Stability**: breakages in Flatpak applications do not affect the system,
   since they run in isolated environments.
 - **Rootless install**: Flatpak does not require elevated privileges to install
   applications or runtimes.
-- **Sandboxed applications**: Flatpak increases security, one of its main goals, by
-  isolating applications from one another and limiting their access to the host environment.
+- **Sandboxed applications**: one of Flatpak's main goals is to increase the security of desktop systems. This is achieved by isolating applications from one another and limiting their access to the host environment.
 
 Flatpak also offers advantages over other universal approaches to Linux application distribution:
 
 - **Decentralized by design**: while Flatpak does provide a centralized service for distributing
   applications, it also offers decentralized hosting and distribution, allowing developers or
   downstreams to host their own applications and application repositories.
-- **Desktop integration**: Flatpak offers native integration with the main Linux desktops,
-  allowing users to easily browse, install, run, and manage Flatpak
-  applications through their existing desktop environment and tools.
+- **Desktop integration**: Flatpak offers native integration with the many Linux desktop environments allowing users to easily browse, install, run, and manage Flatpak
+  applications.
 - **Space efficiency**: Flatpak saves storage by deduplicating libraries and
   other files used by multiple applications.
 - **Delta updates**: only changed files are downloaded during updates.
 
 Other benefits for developers include:
 
-- **Forward-compatibility**: the same Flatpak application can run on different versions of
-  the same distribution, including unreleased versions, without changes from the application
-  developer.
-- **Bundling**: developers can ship almost any dependency or library as part of
-  their applications, giving them control over the softwares used to build them.
-- **Consistent application environments**: because application environments are identical across
-devices, applications run as expected; bug identification, as well as testing, is also made easier.
-- **Branches**: developers can distribute applications from different branches
-  (e.g. ``stable``, ``beta``, etc.) while the application name can stay the same.
-- **Maintained platforms**: Flatpak's maintained runtimes contain collections
-  of dependencies for applications to use, easing development.
+- **Forward-compatibility**: the same Flatpak application can run on different versions of a distribution, including unreleased versions, without needing any changes.
+- **Bundling**: this allows application developers to ship almost any dependency or library as part of their applications, giving them complete control over their application.
+- **Consistent application environments**: Flatpak provides a consistent and identical application runtime environment across devices and distributions. This makes bug identification and testing easier.
+- **Branches**: this allows application developers to distribute multiple branches of an applications (e.g. ``stable``, ``beta``, etc.) while retaining the same name.
+- **Maintained platforms**: Flatpak runtimes contains a collection of common dependencies for the applications to use, easing application development and maintenance.
 
 In general, Flatpak is best suited for desktop applications. While command-line
 applications also work, Flatpak may not be suitable in some cases:


### PR DESCRIPTION
@bbhtt Part of a long-haul effort of mine to polish the English documentation before translation.
Changes:
- A clearer terminology section, especially for `Runtime` and `BaseApp`. The use of `platform` can be vague and unclear for beginners. (Defining something "also known as platform" as an "integrated platform" is just confusing. Below, `BaseApp` is also an "integrated platform", making their differences hard to grasp.)
- Punctuation, prepositional use (e.g, issue with vs. issue of)
- Most other changes are unnecessary, but I kept them because they seem more concise. I'll revert them if they're deemed unacceptable.

P/s: Also a trivial nitpick-y thing, I think the capitalization of `flatpak` should also have consistent rules. For example, `Flatpak` with a uppercase `F` is used (1) for referring to Flatpak the software—Flatpak as a system of building, distributing, and running apps and (2) as a noun modifier (similar to "an IKEA bed/a Nokia phone"), hence "the Flatpak website, a Flatpak app/package". Otherwise, `flatpak` is lowercased when used as a common noun to mean a Flatpak app/package ("this flatpak is heavy/it won't work inside a flatpak/I deleted all my flatpaks). Please ignore this if it's just too silly and trivial a matter to even think about.