### PR TITLE
Add that `/var/run` or subpaths cannot be exposed when symlinked on host

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -110,7 +110,7 @@ is doing. For example, to trace ``openat(), read()`` calls::
 
   $ strace -e trace=openat,read -o strace.log -f /app/bin/<application-binary>
 
-`Perf <https://perf.wiki.kernel.org/index.php/Main_Page>`_ requires
+`Perf <https://perfwiki.github.io/main/>`_ requires
 access to ``--filesystem=/sys`` to run::
 
   $ flatpak run --command=perf --filesystem=/sys --filesystem=$(pwd) --devel $FLATPAK_ID record -v -- <command>

--- a/docs/sandbox-permissions.rst
+++ b/docs/sandbox-permissions.rst
@@ -222,7 +222,8 @@ to them with ``--filesystem`` will have no effect::
 
 The entire ``/run`` is not allowed and all subpaths of ``/run`` except
 ``/run/flatpak, /run/host`` is allowed to be exposed via
-``--filesystem``.
+``--filesystem``. Additionally, if ``/var/run`` on host is a symlink to
+``../run``, exposing it or a subpath of it, is not allowed.
 
 Additionally the following directories from host need to be explicitly
 requested with ``--filesystem`` and are not available with


### PR DESCRIPTION
Flatpak internally sets up a /var/run to /run symlink https://github.com/flatpak/flatpak/blob/fd1b7e444016d1b44bdab7cb5642b0ac83bd4b9e/common/flatpak-run.c#L2281. If it is symlinked on host too, when using `--filesystem=var/run/subpath` bwrap gets called twice to create the same symlink and the second one will fail.

See also https://github.com/containers/bubblewrap/commit/4109d59251fdb0800cf7e742791ba2b35a1f0f25