### PR TITLE
Add --device=dri to the electron packaging example

### DIFF
--- a/docs/electron.rst
+++ b/docs/electron.rst
@@ -116,6 +116,7 @@ access.
 
   finish-args:
     - --share=ipc
+    - --device=dri
     - --socket=x11
     - --socket=pulseaudio
     - --share=network


### PR DESCRIPTION
I have observed that some users are unable to launch electron based apps due to this missing permission. So, adding this flag in the example

See: https://github.com/flathub/io.frappe.books/issues/1