### PR TITLE
Add Gir.Core to the list of GUI frameworks

### DIFF
--- a/docs/dotnet.rst
+++ b/docs/dotnet.rst
@@ -9,6 +9,7 @@ Prerequisites
     - `Uno Platform <https://platform.uno/>`_
     - `Eto <https://github.com/picoe/Eto>`_
     - `GTKSharp <https://github.com/GtkSharp/GtkSharp>`_
+    - `Gir.Core <https://gircore.github.io/>`_
 - The application's source code is hosted on a Git server such as GitHub, GitLab, or Bitbucket
 
 Steps for Packaging


### PR DESCRIPTION
It provides bindings for Gtk4 and other GObject libraries.
Should we remove GtkSharp - it is unmaintained since 2023?