### PR TITLE
 conf: Ignore all FDO urls for linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,6 +163,7 @@ linkcheck_anchors_ignore_for_url = [
 
 linkcheck_ignore = [
     r"https://www\.gnu\.org/.*",  # Broken in GitHub actions
+    r"https://www\.freedesktop\.org/.*", # Uses Anubis so get "418 Client Error: I'm a teapot for url: ..."
 ]
 
 # -- Options for manual page output ---------------------------------------


### PR DESCRIPTION
Broken in GitHub actions, possibly FDO is blocking it:

  418 Client Error: I'm a teapot for url: ...

/cc @bbhtt 